### PR TITLE
온보딩 화면 수정 및 햄버거 모달 및 카테고리 추가 작업

### DIFF
--- a/backend/src/main/java/com/example/focusapp/controller/GoalCalendarController.java
+++ b/backend/src/main/java/com/example/focusapp/controller/GoalCalendarController.java
@@ -1,0 +1,30 @@
+package com.example.focusapp.controller;
+
+import com.example.focusapp.dto.GoalCalendarResponse;
+import com.example.focusapp.service.GoalCalendarService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/goal-plans")
+public class GoalCalendarController {
+
+    private final GoalCalendarService goalCalendarService;
+
+    @GetMapping("/{goalPlanId}/calendar")
+    public ResponseEntity<GoalCalendarResponse> getCompletedDates(
+            @PathVariable Long goalPlanId,
+            @RequestParam int year,
+            @RequestParam int month
+    ) {
+        return ResponseEntity.ok(
+                goalCalendarService.getCompletedDates(goalPlanId, year, month)
+        );
+    }
+}

--- a/backend/src/main/java/com/example/focusapp/controller/GoalPlanController.java
+++ b/backend/src/main/java/com/example/focusapp/controller/GoalPlanController.java
@@ -2,6 +2,8 @@ package com.example.focusapp.controller;
 
 import com.example.focusapp.dto.GoalPlanResponse;
 import com.example.focusapp.dto.UpdateGoalRequest;
+import com.example.focusapp.dto.SetupRequest;
+import com.example.focusapp.dto.SetupResponse;
 import com.example.focusapp.service.GoalPlanService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -24,13 +26,21 @@ public class GoalPlanController {
         return ResponseEntity.ok(goalPlanService.getGoalPlans(userId));
     }
 
+    @GetMapping("/{goalId}")
+    public ResponseEntity<GoalPlanResponse> getGoal(@PathVariable Long goalId) {
+        return ResponseEntity.ok(goalPlanService.getGoal(goalId));
+    }
+
     @GetMapping("/users/{userId}/active")
     public ResponseEntity<List<GoalPlanResponse>> getActiveGoals(
             @PathVariable Long userId
     ) {
         return ResponseEntity.ok(goalPlanService.getActiveGoals(userId));
     }
-
+    @PostMapping
+    public ResponseEntity<SetupResponse> createGoalPlan(@RequestBody SetupRequest request){
+        return ResponseEntity.ok(goalPlanService.createGoalPlan(request));
+    }
     @PatchMapping("/{goalId}")
     public ResponseEntity<GoalPlanResponse> updateGoal(
             @PathVariable Long goalId,

--- a/backend/src/main/java/com/example/focusapp/controller/UserController.java
+++ b/backend/src/main/java/com/example/focusapp/controller/UserController.java
@@ -39,4 +39,8 @@ public class UserController {
     ) {
         return ResponseEntity.ok(userService.updateTheme(userId, theme));
     }
+    @PostMapping("/guest")
+    public ResponseEntity<?> createGuestUser() {
+        return ResponseEntity.ok(userService.createGuestUser());
+    }
 }

--- a/backend/src/main/java/com/example/focusapp/dto/GoalCalendarResponse.java
+++ b/backend/src/main/java/com/example/focusapp/dto/GoalCalendarResponse.java
@@ -1,0 +1,39 @@
+package com.example.focusapp.dto;
+
+import java.util.List;
+
+public class GoalCalendarResponse {
+    private Long goalId;
+    private String preferredEmoji;
+    private int year;
+    private int month;
+    private List<String> completedDates;
+
+public GoalCalendarResponse(Long goalId, String preferredEmoji, int year, int month, List<String> completedDates) {
+    this.goalId = goalId;
+    this.preferredEmoji = preferredEmoji;
+    this.year = year;
+    this.month = month;
+    this.completedDates = completedDates;
+}
+
+    public Long getGoalId() {
+        return goalId;
+    }
+
+    public String getPreferredEmoji() {
+        return preferredEmoji;
+    }
+
+    public int getYear() {
+        return year;
+    }
+
+    public int getMonth() {
+        return month;
+    }
+
+    public List<String> getCompletedDates() {
+        return completedDates;
+    }
+}

--- a/backend/src/main/java/com/example/focusapp/dto/GoalPlanResponse.java
+++ b/backend/src/main/java/com/example/focusapp/dto/GoalPlanResponse.java
@@ -13,4 +13,5 @@ public class GoalPlanResponse {
     private Long characterId;
     private String characterName;
     private boolean isActive;
+    private String motto;
 }

--- a/backend/src/main/java/com/example/focusapp/repository/DailyTaskRepository.java
+++ b/backend/src/main/java/com/example/focusapp/repository/DailyTaskRepository.java
@@ -8,6 +8,9 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
 public interface DailyTaskRepository extends JpaRepository<DailyTask, Long> {
     boolean existsByGoalPlanAndTargetDate(GoalPlan goalPlan, LocalDate targetDate);
     boolean existsByGoalPlanIdAndTargetDate(Long goalPlanId, LocalDate targetDate);
@@ -25,5 +28,20 @@ public interface DailyTaskRepository extends JpaRepository<DailyTask, Long> {
     Optional<DailyTask> findTopByGoalPlanAndTargetDateLessThanEqualOrderByTargetDateDesc(
             GoalPlan goalPlan,
             LocalDate date
+    );
+    @Query(value = """
+        SELECT dt.target_date
+          FROM daily_tasks dt
+         WHERE dt.goal_plan_id  = :goalPlanId
+         AND dt.target_date >= :startDate
+         AND dt.target_date < :endDate
+         GROUP BY dt.goal_plan_id,target_date
+        HAVING COUNT(*) = SUM(CASE WHEN dt.completed = 1 THEN 1 ELSE 0 END)
+         ORDER BY dt.target_date
+        """, nativeQuery = true)
+    List<java.sql.Date> findCompletedDatesByGoalPlanId(
+            @Param("goalPlanId") Long goalPlanId,
+            @Param("startDate") LocalDate startDate,
+            @Param("endDate") LocalDate endDate
     );
 }

--- a/backend/src/main/java/com/example/focusapp/service/CharacterService.java
+++ b/backend/src/main/java/com/example/focusapp/service/CharacterService.java
@@ -35,10 +35,17 @@ public class CharacterService {
         GoalPlan goalPlan = goalPlanRepository.findActiveByUserId(userId)
                 .orElseThrow(() -> new NotFoundException("GoalPlan 없음"));
 
+        System.out.println("goalPlanId = " + goalPlan.getId());
+        System.out.println("level = " + goalPlan.getCurrentLevel());
+        System.out.println("characterId = " + goalPlan.getCharacter().getId());
+
+
         int level = goalPlan.getCurrentLevel();
         Long characterId = goalPlan.getCharacter().getId();
 
         int imageLevel = convertLevelToImageLevel(level);
+
+        System.out.println("imageLevel = " + imageLevel);
 
         CharacterImage image = characterImageRepository
                 .findByCharacterIdAndLevel(characterId, imageLevel)

--- a/backend/src/main/java/com/example/focusapp/service/GoalCalendarService.java
+++ b/backend/src/main/java/com/example/focusapp/service/GoalCalendarService.java
@@ -1,0 +1,50 @@
+package com.example.focusapp.service;
+
+import com.example.focusapp.dto.GoalCalendarResponse;
+import com.example.focusapp.entity.GoalPlan;
+import com.example.focusapp.repository.DailyTaskRepository;
+import com.example.focusapp.repository.GoalPlanRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class GoalCalendarService {
+
+    private final GoalPlanRepository goalPlanRepository;
+    private final DailyTaskRepository dailyTaskRepository;
+
+    public GoalCalendarResponse getCompletedDates(Long goalPlanId, int year, int month) {
+        GoalPlan goalPlan = goalPlanRepository.findById(goalPlanId)
+                .orElseThrow(() -> new IllegalArgumentException("Goal plan not found"));
+
+
+
+        LocalDate startDate = LocalDate.of(year, month, 1);
+        LocalDate endDate = startDate.plusMonths(1);
+
+        List<java.sql.Date> dates = dailyTaskRepository.findCompletedDatesByGoalPlanId(
+                goalPlanId, startDate, endDate
+        );
+
+        List<String> completedDates = dates.stream()
+                .map(date -> date.toLocalDate().toString())
+                .toList();
+
+        String preferredEmoji = goalPlan.getGoalConfig() != null
+                ? goalPlan.getGoalConfig().getPreferredEmoji()
+                : "🌱";
+
+        return new GoalCalendarResponse(
+                goalPlanId,
+                preferredEmoji,
+                year,
+                month,
+                completedDates
+        );
+    }
+}

--- a/backend/src/main/java/com/example/focusapp/service/GoalPlanService.java
+++ b/backend/src/main/java/com/example/focusapp/service/GoalPlanService.java
@@ -2,10 +2,15 @@ package com.example.focusapp.service;
 
 import com.example.focusapp.dto.GoalPlanResponse;
 import com.example.focusapp.dto.UpdateGoalRequest;
+import com.example.focusapp.dto.SetupRequest;
+import com.example.focusapp.dto.SetupResponse;
 import com.example.focusapp.entity.*;
 import com.example.focusapp.entity.Character;
 import com.example.focusapp.repository.CharacterRepository;
 import com.example.focusapp.repository.GoalPlanRepository;
+import com.example.focusapp.repository.UserRepository;
+import com.example.focusapp.repository.GoalDefinitionRepository;
+import com.example.focusapp.repository.GoalConfigRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -19,6 +24,11 @@ public class GoalPlanService {
 
     private final GoalPlanRepository goalPlanRepository;
     private final CharacterRepository characterRepository;
+
+    private final UserRepository userRepository;
+    private final GoalDefinitionRepository goalDefinitionRepository;
+    private final GoalConfigRepository goalConfigRepository;
+    private final DailyTaskService dailyTaskService;
 
     @Transactional
     public List<GoalPlanResponse> getGoalPlans(Long userId) {
@@ -73,6 +83,81 @@ public class GoalPlanService {
 
         return toDto(plan);
     }
+    //sje 추가
+    @Transactional(readOnly = true)
+    public GoalPlanResponse getGoal(Long goalId) {
+        GoalPlan plan = goalPlanRepository.findById(goalId)
+                .orElseThrow(() -> new IllegalArgumentException("목표가 존재하지 않습니다."));
+
+        updateStatusIfExpired(plan);
+
+        return toDto(plan);
+    }
+
+    @Transactional
+    public SetupResponse createGoalPlan(SetupRequest request) {
+        User user = userRepository.findById(request.getUserId())
+                .orElseThrow(() -> new IllegalArgumentException("사용자가 존재하지 않습니다."));
+
+        boolean hasUsername = user.getUsername() != null && !user.getUsername().trim().isEmpty();
+        if (!hasUsername) {
+            throw new IllegalStateException("별명을 먼저 설정해주세요.");
+        }
+
+        boolean alreadyHasGoal = goalDefinitionRepository.existsByUserIdAndTitle(
+                request.getUserId(), request.getGoalTitle().trim());
+        if (alreadyHasGoal) {
+            throw new IllegalStateException("이미 목표가 존재합니다.");
+        }
+
+        GoalDefinition goalDefinition = new GoalDefinition();
+        goalDefinition.setUserId(request.getUserId());
+        goalDefinition.setTitle(request.getGoalTitle());
+        goalDefinition.setMotto(request.getMotto());
+        goalDefinition = goalDefinitionRepository.save(goalDefinition);
+
+        GoalPlan goalPlan = new GoalPlan();
+        goalPlan.setGoalDefinition(goalDefinition);
+
+        Character character = characterRepository.findById(request.getCharacterId())
+                .orElseThrow(() -> new IllegalArgumentException("캐릭터가 존재하지 않습니다."));
+
+        goalPlan.setCharacter(character);
+        goalPlan.setStartDate(request.getStartDate());
+        goalPlan.setEndDate(request.getEndDate());
+        goalPlan.setCurrentLevel(1);
+        goalPlan.setStatus(GoalStatus.ACTIVE);
+        goalPlan.setUser(user);
+
+        goalPlan = goalPlanRepository.save(goalPlan);
+
+        String emoji = request.getPreferredEmoji();
+        if (emoji == null || emoji.trim().isEmpty()) {
+            throw new IllegalArgumentException("이모지를 입력해주세요.");
+        }
+
+        GoalConfig goalConfig = GoalConfig.builder()
+                .goalPlan(goalPlan)
+                .alarmCycle(request.getAlarmCycle())
+                .preferredEmoji(request.getPreferredEmoji())
+                .build();
+
+        goalConfigRepository.saveAndFlush(goalConfig);
+
+        dailyTaskService.generateInitialTasks(goalPlan.getId());
+
+        return new SetupResponse(
+                goalPlan.getId(),
+                goalPlan.getUser().getId(),
+                goalPlan.getGoalDefinitionId(),
+                goalPlan.getCharacter().getId(),
+                goalPlan.getStartDate(),
+                goalPlan.getEndDate(),
+                goalPlan.getStatus().toString(),
+                goalDefinition.getTitle(),
+                "목표 설정이 완료되었습니다."
+        );
+    }
 
     @Transactional
     public GoalPlanResponse updateStatus(Long goalId, String status) {
@@ -126,6 +211,10 @@ public class GoalPlanService {
                 ? plan.getCharacter().getName()
                 : null;
 
+        String motto = plan.getGoalDefinition() != null
+                ? plan.getGoalDefinition().getMotto()
+                : null;
+
         boolean active = plan.getStatus() == GoalStatus.ACTIVE;
 
         return new GoalPlanResponse(
@@ -134,7 +223,8 @@ public class GoalPlanService {
                 emoji,
                 characterId,
                 characterName,
-                active
+                active,
+                motto
         );
     }
 }

--- a/backend/src/main/java/com/example/focusapp/service/OnboardingService.java
+++ b/backend/src/main/java/com/example/focusapp/service/OnboardingService.java
@@ -13,9 +13,13 @@ import com.example.focusapp.repository.GoalPlanRepository;
 import com.example.focusapp.repository.CharacterRepository;
 import com.example.focusapp.repository.UserRepository;
 import com.example.focusapp.service.DailyTaskService;
+import com.example.focusapp.service.GoalPlanService;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import lombok.RequiredArgsConstructor;
 
+@RequiredArgsConstructor
 @Service
 public class OnboardingService {
 
@@ -25,22 +29,23 @@ public class OnboardingService {
     private final GoalConfigRepository goalConfigRepository;
     private final DailyTaskService dailyTaskService;
     private final CharacterRepository characterRepository;
+    private final GoalPlanService goalPlanService;
 
-    public OnboardingService(
-            UserRepository userRepository,
-            GoalDefinitionRepository goalDefinitionRepository,
-            GoalPlanRepository goalPlanRepository,
-            GoalConfigRepository goalConfigRepository,
-            DailyTaskService dailyTaskService,
-            CharacterRepository characterRepository
-    ) {
-        this.userRepository = userRepository;
-        this.goalDefinitionRepository = goalDefinitionRepository;
-        this.goalPlanRepository = goalPlanRepository;
-        this.goalConfigRepository = goalConfigRepository;
-        this.dailyTaskService = dailyTaskService;
-        this.characterRepository = characterRepository;
-    }
+//    public OnboardingService(
+//            UserRepository userRepository,
+//            GoalDefinitionRepository goalDefinitionRepository,
+//            GoalPlanRepository goalPlanRepository,
+//            GoalConfigRepository goalConfigRepository,
+//            DailyTaskService dailyTaskService,
+//            CharacterRepository characterRepository
+//    ) {
+//        this.userRepository = userRepository;
+//        this.goalDefinitionRepository = goalDefinitionRepository;
+//        this.goalPlanRepository = goalPlanRepository;
+//        this.goalConfigRepository = goalConfigRepository;
+//        this.dailyTaskService = dailyTaskService;
+//        this.characterRepository = characterRepository;
+//    }
 
     @Transactional(readOnly = true)
     public OnboardingStatusResponse getStatus(Long userId) {
@@ -103,80 +108,68 @@ public class OnboardingService {
 
     @Transactional
     public SetupResponse setup(SetupRequest request) {
-        System.out.println("1. setup 진입");
-        User user = userRepository.findById(request.getUserId())
-                .orElseThrow(() -> new IllegalArgumentException("사용자가 존재하지 않습니다."));
-        System.out.println("2. user 조회 성공: " + user.getId());
-
-        boolean hasUsername = user.getUsername() != null && !user.getUsername().trim().isEmpty();
-        System.out.println("3. hasUsername: " + hasUsername);
-        if (!hasUsername) {
-            throw new IllegalStateException("별명을 먼저 설정해주세요.");
-        }
-
-        boolean alreadyHasGoal = goalDefinitionRepository.existsByUserIdAndTitle(
-                request.getUserId(),request.getGoalTitle().trim());
-        System.out.println("4. alreadyHasGoal: " + alreadyHasGoal);
-        if (alreadyHasGoal) {
-            throw new IllegalStateException("이미 목표가 존재합니다.");
-        }
-
-        GoalDefinition goalDefinition = new GoalDefinition();
-        goalDefinition.setUserId(request.getUserId());
-        goalDefinition.setTitle(request.getGoalTitle());
-        goalDefinition.setMotto(request.getMotto());
-        System.out.println("5. goalDefinition save 직전");
-        goalDefinition = goalDefinitionRepository.save(goalDefinition);
-        System.out.println("6. goalDefinition save 성공: " + goalDefinition.getId());
-
-
-        GoalPlan goalPlan = new GoalPlan();
-        goalPlan.setGoalDefinition(goalDefinition);
-
-        Character character = characterRepository.findById(request.getCharacterId())
-                .orElseThrow(() -> new IllegalArgumentException("캐릭터 없음"));
-
-        goalPlan.setCharacter(character);
-
-        goalPlan.setStartDate(request.getStartDate());
-        goalPlan.setEndDate(request.getEndDate());
-        goalPlan.setCurrentLevel(1); // 레벨 1로 초기화
-        goalPlan.setStatus(GoalStatus.ACTIVE);
-        goalPlan.setUser(user);
-
-        System.out.println("7. goalPlan save 직전");
-        goalPlan = goalPlanRepository.save(goalPlan);
-        System.out.println("8. goalPlan save 성공: " + goalPlan.getId());
-
-        System.out.println(
-                "[OnboardingService] ✅ setup 저장 완료 | goalPlanId=" + goalPlan.getId()
-                        + ", userId=" + goalPlan.getCharacter().getId()
-                        + ", goalDefinitionId=" + goalPlan.getGoalDefinition().getId()
-                        + ", alarmCycle=" + request.getAlarmCycle()
-                        + ", emoji=" + request.getPreferredEmoji()
-        );
-
-        // 주기 생성
-        GoalConfig goalConfig = GoalConfig.builder()
-                .goalPlan(goalPlan)
-                .alarmCycle(request.getAlarmCycle())
-                .preferredEmoji(request.getPreferredEmoji())
-                .build();
-
-        goalConfigRepository.saveAndFlush(goalConfig);
-
-        dailyTaskService.generateInitialTasks(goalPlan.getId());
-
-        return new SetupResponse(
-                goalPlan.getId(),
-                goalPlan.getUser().getId(),
-                goalPlan.getGoalDefinitionId(),
-                goalPlan.getCharacter().getId(),
-                goalPlan.getStartDate(),
-                goalPlan.getEndDate(),
-                goalPlan.getStatus().toString(),
-                goalDefinition.getTitle(),
-                "목표 설정이 완료되었습니다."
-        );
+        return goalPlanService.createGoalPlan(request);
+//        User user = userRepository.findById(request.getUserId())
+//                .orElseThrow(() -> new IllegalArgumentException("사용자가 존재하지 않습니다."));
+//
+//        boolean hasUsername = user.getUsername() != null && !user.getUsername().trim().isEmpty();
+//        if (!hasUsername) {
+//            throw new IllegalStateException("별명을 먼저 설정해주세요.");
+//        }
+//
+//        boolean alreadyHasGoal = goalDefinitionRepository.existsByUserIdAndTitle(
+//                request.getUserId(),request.getGoalTitle().trim());
+//        if (alreadyHasGoal) {
+//            throw new IllegalStateException("이미 목표가 존재합니다.");
+//        }
+//
+//        GoalDefinition goalDefinition = new GoalDefinition();
+//        goalDefinition.setUserId(request.getUserId());
+//        goalDefinition.setTitle(request.getGoalTitle());
+//        goalDefinition.setMotto(request.getMotto());
+//        goalDefinition = goalDefinitionRepository.save(goalDefinition);
+//
+//
+//        GoalPlan goalPlan = new GoalPlan();
+//        goalPlan.setGoalDefinition(goalDefinition);
+//
+//        Character character = characterRepository.findById(request.getCharacterId())
+//                .orElseThrow(() -> new IllegalArgumentException("캐릭터 없음"));
+//
+//        goalPlan.setCharacter(character);
+//
+//        goalPlan.setStartDate(request.getStartDate());
+//        goalPlan.setEndDate(request.getEndDate());
+//        goalPlan.setCurrentLevel(1); // 레벨 1로 초기화
+//        goalPlan.setStatus(GoalStatus.ACTIVE);
+//        goalPlan.setUser(user);
+//
+//        goalPlan = goalPlanRepository.save(goalPlan);
+//
+//
+//
+//        // 주기 생성
+//        GoalConfig goalConfig = GoalConfig.builder()
+//                .goalPlan(goalPlan)
+//                .alarmCycle(request.getAlarmCycle())
+//                .preferredEmoji(request.getPreferredEmoji())
+//                .build();
+//
+//        goalConfigRepository.saveAndFlush(goalConfig);
+//
+//        dailyTaskService.generateInitialTasks(goalPlan.getId());
+//
+//        return new SetupResponse(
+//                goalPlan.getId(),
+//                goalPlan.getUser().getId(),
+//                goalPlan.getGoalDefinitionId(),
+//                goalPlan.getCharacter().getId(),
+//                goalPlan.getStartDate(),
+//                goalPlan.getEndDate(),
+//                goalPlan.getStatus().toString(),
+//                goalDefinition.getTitle(),
+//                "목표 설정이 완료되었습니다."
+//        );
+//    }
     }
 }

--- a/backend/src/main/java/com/example/focusapp/service/UserService.java
+++ b/backend/src/main/java/com/example/focusapp/service/UserService.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.example.focusapp.dto.UserResponse;
+import com.example.focusapp.dto.GuestUserResponse;
 
 @Service
 public class UserService {
@@ -17,6 +18,19 @@ public class UserService {
     private User getUserEntity(Long userId) {
         return userRepository.findById(userId)
                 .orElseThrow(() -> new IllegalArgumentException("사용자가 존재하지 않습니다."));
+    }
+
+    @Transactional
+    public GuestUserResponse createGuestUser() {
+        User user = new User();
+        user.setUsername(null);
+        user = userRepository.save(user);
+
+        return new GuestUserResponse(
+                user.getId(),
+                user.getUsername(),
+                "게스트 사용자가 생성되었습니다."
+        );
     }
 
     @Transactional(readOnly = true)

--- a/frontend/app.json
+++ b/frontend/app.json
@@ -9,7 +9,8 @@
       "**/*"
     ],
     "plugins": [
-      "expo-asset"
+      "expo-asset",
+      "expo-font"
     ]
   }
 }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,7 +8,7 @@
       "name": "focus-pixel-frontend",
       "version": "1.0.0",
       "dependencies": {
-        "@expo/vector-icons": "^15.1.1",
+        "@expo/vector-icons": "^14.1.0",
         "@react-native-async-storage/async-storage": "2.1.2",
         "@react-navigation/bottom-tabs": "^6.6.1",
         "@react-navigation/native": "^6.1.18",
@@ -16,6 +16,7 @@
         "axios": "^1.7.2",
         "expo": "~53.0.0",
         "expo-asset": "~11.1.7",
+        "expo-font": "~13.3.2",
         "expo-haptics": "^55.0.14",
         "expo-linear-gradient": "~14.1.5",
         "expo-media-library": "~17.1.7",
@@ -27,7 +28,7 @@
         "react-native-confetti-cannon": "^1.5.2",
         "react-native-keyboard-aware-scroll-view": "^0.9.5",
         "react-native-linear-gradient": "^2.8.3",
-        "react-native-safe-area-context": "5.4.0",
+        "react-native-safe-area-context": "^5.7.0",
         "react-native-screens": "~4.11.1",
         "react-native-share": "^12.2.6",
         "react-native-toast-message": "^2.3.3",
@@ -1944,12 +1945,12 @@
       "license": "MIT"
     },
     "node_modules/@expo/vector-icons": {
-      "version": "15.1.1",
-      "resolved": "https://registry.npmjs.org/@expo/vector-icons/-/vector-icons-15.1.1.tgz",
-      "integrity": "sha512-Iu2VkcoI5vygbtYngm7jb4ifxElNVXQYdDrYkT7UCEIiKLeWnQY0wf2ZhHZ+Wro6Sc5TaumpKUOqDRpLi5rkvw==",
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/@expo/vector-icons/-/vector-icons-14.1.0.tgz",
+      "integrity": "sha512-7T09UE9h8QDTsUeMGymB4i+iqvtEeaO5VvUjryFB4tugDTG/bkzViWA74hm5pfjjDEhYMXWaX112mcvhccmIwQ==",
       "license": "MIT",
       "peerDependencies": {
-        "expo-font": ">=14.0.4",
+        "expo-font": "*",
         "react": "*",
         "react-native": "*"
       }
@@ -4341,18 +4342,16 @@
       }
     },
     "node_modules/expo-font": {
-      "version": "55.0.6",
-      "resolved": "https://registry.npmjs.org/expo-font/-/expo-font-55.0.6.tgz",
-      "integrity": "sha512-x9czUA3UQWjIwa0ZUEs/eWJNqB4mAue/m4ltESlNPLZhHL0nWWqIfsyHmklTLFH7mVfcHSJvew6k+pR2FE1zVw==",
+      "version": "13.3.2",
+      "resolved": "https://registry.npmjs.org/expo-font/-/expo-font-13.3.2.tgz",
+      "integrity": "sha512-wUlMdpqURmQ/CNKK/+BIHkDA5nGjMqNlYmW0pJFXY/KE/OG80Qcavdu2sHsL4efAIiNGvYdBS10WztuQYU4X0A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fontfaceobserver": "^2.1.0"
       },
       "peerDependencies": {
         "expo": "*",
-        "react": "*",
-        "react-native": "*"
+        "react": "*"
       }
     },
     "node_modules/expo-haptics": {
@@ -4435,17 +4434,6 @@
         "react-native": "*"
       }
     },
-    "node_modules/expo/node_modules/@expo/vector-icons": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/@expo/vector-icons/-/vector-icons-14.1.0.tgz",
-      "integrity": "sha512-7T09UE9h8QDTsUeMGymB4i+iqvtEeaO5VvUjryFB4tugDTG/bkzViWA74hm5pfjjDEhYMXWaX112mcvhccmIwQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "expo-font": "*",
-        "react": "*",
-        "react-native": "*"
-      }
-    },
     "node_modules/expo/node_modules/expo-file-system": {
       "version": "18.1.11",
       "resolved": "https://registry.npmjs.org/expo-file-system/-/expo-file-system-18.1.11.tgz",
@@ -4454,19 +4442,6 @@
       "peerDependencies": {
         "expo": "*",
         "react-native": "*"
-      }
-    },
-    "node_modules/expo/node_modules/expo-font": {
-      "version": "13.3.2",
-      "resolved": "https://registry.npmjs.org/expo-font/-/expo-font-13.3.2.tgz",
-      "integrity": "sha512-wUlMdpqURmQ/CNKK/+BIHkDA5nGjMqNlYmW0pJFXY/KE/OG80Qcavdu2sHsL4efAIiNGvYdBS10WztuQYU4X0A==",
-      "license": "MIT",
-      "dependencies": {
-        "fontfaceobserver": "^2.1.0"
-      },
-      "peerDependencies": {
-        "expo": "*",
-        "react": "*"
       }
     },
     "node_modules/expo/node_modules/expo-keep-awake": {
@@ -7224,9 +7199,9 @@
       }
     },
     "node_modules/react-native-safe-area-context": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/react-native-safe-area-context/-/react-native-safe-area-context-5.4.0.tgz",
-      "integrity": "sha512-JaEThVyJcLhA+vU0NU8bZ0a1ih6GiF4faZ+ArZLqpYbL6j7R3caRqj+mE3lEtKCuHgwjLg3bCxLL1GPUJZVqUA==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/react-native-safe-area-context/-/react-native-safe-area-context-5.7.0.tgz",
+      "integrity": "sha512-/9/MtQz8ODphjsLdZ+GZAIcC/RtoqW9EeShf7Uvnfgm/pzYrJ75y3PV/J1wuAV1T5Dye5ygq4EAW20RoBq0ABQ==",
       "license": "MIT",
       "peerDependencies": {
         "react": "*",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,7 +10,7 @@
     "web": "expo start --web"
   },
   "dependencies": {
-    "@expo/vector-icons": "^15.1.1",
+    "@expo/vector-icons": "^14.1.0",
     "@react-native-async-storage/async-storage": "2.1.2",
     "@react-navigation/bottom-tabs": "^6.6.1",
     "@react-navigation/native": "^6.1.18",
@@ -18,6 +18,7 @@
     "axios": "^1.7.2",
     "expo": "~53.0.0",
     "expo-asset": "~11.1.7",
+    "expo-font": "~13.3.2",
     "expo-haptics": "^55.0.14",
     "expo-linear-gradient": "~14.1.5",
     "expo-media-library": "~17.1.7",
@@ -29,7 +30,7 @@
     "react-native-confetti-cannon": "^1.5.2",
     "react-native-keyboard-aware-scroll-view": "^0.9.5",
     "react-native-linear-gradient": "^2.8.3",
-    "react-native-safe-area-context": "5.4.0",
+    "react-native-safe-area-context": "^5.7.0",
     "react-native-screens": "~4.11.1",
     "react-native-share": "^12.2.6",
     "react-native-toast-message": "^2.3.3",

--- a/frontend/src/components/DailyTaskSection.tsx
+++ b/frontend/src/components/DailyTaskSection.tsx
@@ -11,11 +11,13 @@ export default function DailyTaskSection({
                                              onLevelChange,
                                              refreshKey,
                                              onLevelUp,
+                                             onTasksUpdated,
                                          }: {
     goalPlanId: number;
     onLevelChange?: (level: number) => void;
     refreshKey?: number;
     onLevelUp?: () => void;
+    onTasksUpdated?: () => void;
 }) {
     const [tasks, setTasks] = useState<Task[]>([]);
     const [levelUpTrigger, setLevelUpTrigger] = useState(false);
@@ -141,6 +143,7 @@ export default function DailyTaskSection({
 
             onLevelChange?.(currentLevel);
             onLevelUp?.();
+            onTasksUpdated?.();
 
             if (messageType === 'LEVEL_UP') {
                 setLevelUpTrigger(true);

--- a/frontend/src/components/MonthlyCalendar.tsx
+++ b/frontend/src/components/MonthlyCalendar.tsx
@@ -1,82 +1,323 @@
-import { StyleSheet, Text, View } from 'react-native';
-import { colors } from '../theme/colors';
+import React from 'react';
+import { View, Text, StyleSheet, TouchableOpacity, useColorScheme } from 'react-native';
 
-const days = Array.from({ length: 31 }, (_, i) => i + 1);
-const weekLabels = ['월', '화', '수', '목', '금', '토', '일'];
-const activeDays = new Set([3, 11, 12, 23, 24, 25, 26, 27, 28]);
+type MonthlyCalendarProps = {
+  year: number;
+  month: number; // 1~12
+  completedDates?: string[];
+  preferredEmoji?: string;
+  onPrevMonth?: () => void;
+  onNextMonth?: () => void;
+  onPressToday?: () => void;
+  selectedDate?: string;
+  onPressDate?: (date: string) => void;
+};
 
-export default function MonthlyCalendar() {
+export default function MonthlyCalendar({
+                                          year,
+                                          month,
+                                          completedDates = [],
+                                          preferredEmoji = '🌱',
+                                          onPrevMonth,
+                                          onNextMonth,
+                                          onPressToday,
+                                          selectedDate,
+                                          onPressDate
+                                        }: MonthlyCalendarProps) {
+  const scheme = useColorScheme();
+  const isDark = scheme === 'dark';
+
+  const daysInMonth = new Date(year, month, 0).getDate();
+  const firstDayOfWeek = new Date(year, month - 1, 1).getDay();
+
+  const days = Array.from({ length: daysInMonth }, (_, i) => i + 1);
+  const emptyCells = Array.from({ length: firstDayOfWeek }, (_, i) => `empty-${i}`);
+  const calendarCells = [...emptyCells, ...days];
+
+  const today = new Date();
+  const isCurrentMonth =
+      today.getFullYear() === year && today.getMonth() + 1 === month;
+
+  const colors = {
+    cardBg: isDark ? '#151518' : '#FFFFFF',
+    cardBorder: isDark ? '#26262B' : '#F0F0F3',
+    title: isDark ? '#F5F5F7' : '#222222',
+    sub: isDark ? '#9B9BA1' : '#9A9A9A',
+    actionBg: isDark ? '#232329' : '#F4F4F6',
+    actionText: isDark ? '#D8D8DD' : '#555555',
+    weekText: isDark ? '#7E7E88' : '#A0A0A0',
+    dayText: isDark ? '#F2F2F4' : '#3A3A3A',
+    todayBg: isDark ? '#1E2C42' : '#EEF5FF',
+    todayBorder: '#8FD9A3',
+    todayText: '#B7F0C4',
+    badgeBg: isDark ? '#2A2418' : '#FFF7E8',
+    selectedBg: '#B8F1C6',
+    selectedText: '#1E3A2A',
+    selectedBorder: '#BFF3CC',
+  };
+
   return (
-    <View style={styles.container}>
-      <Text style={styles.title}>2026년 3월</Text>
-      <View style={styles.weekRow}>
-        {weekLabels.map((label) => (
-          <Text key={label} style={styles.weekLabel}>{label}</Text>
-        ))}
+      <View
+          style={[
+            styles.card,
+            {
+              backgroundColor: colors.cardBg,
+              borderColor: colors.cardBorder,
+            },
+          ]}
+      >
+        <View style={styles.headerRow}>
+          <View>
+            <Text style={[styles.headerTitle, { color: colors.title }]}>
+              {year}년 {month}월
+            </Text>
+            <Text style={[styles.headerSub, { color: colors.sub }]}>
+              이번 달 달성 현황
+            </Text>
+          </View>
+
+          <View style={styles.headerActions}>
+            <TouchableOpacity
+                style={[styles.iconButton, { backgroundColor: colors.actionBg }]}
+                onPress={onPrevMonth}
+            >
+              <Text style={[styles.iconText, { color: colors.actionText }]}>‹</Text>
+            </TouchableOpacity>
+
+            <TouchableOpacity
+                style={[styles.todayButton, { backgroundColor: colors.actionBg }]}
+                onPress={onPressToday}
+            >
+              <Text style={[styles.todayButtonText, { color: colors.actionText }]}>오늘</Text>
+            </TouchableOpacity>
+
+            <TouchableOpacity
+                style={[styles.iconButton, { backgroundColor: colors.actionBg }]}
+                onPress={onNextMonth}
+            >
+              <Text style={[styles.iconText, { color: colors.actionText }]}>›</Text>
+            </TouchableOpacity>
+          </View>
+        </View>
+
+        <View style={styles.weekRow}>
+          {['일', '월', '화', '수', '목', '금', '토'].map((day) => (
+              <Text
+                  key={day}
+                  style={[
+                    styles.weekText,
+                    { color: colors.weekText },
+                    day === '일' && styles.sundayText,
+                    day === '토' && styles.saturdayText,
+                  ]}
+              >
+                {day}
+              </Text>
+          ))}
+        </View>
+
+        <View style={styles.grid}>
+          {calendarCells.map((cell) => {
+            if (typeof cell === 'string') {
+              return <View key={cell} style={[styles.dayCell, styles.emptyCell]} />;
+            }
+
+            const day = cell;
+            const dateKey = `${year}-${String(month).padStart(2, '0')}-${String(day).padStart(2, '0')}`;
+            const isCompleted = completedDates.includes(dateKey);
+            const isToday = isCurrentMonth && today.getDate() === day;
+
+            const isSelected = selectedDate === dateKey;
+            return (
+                <TouchableOpacity
+                    key={day}
+                    activeOpacity={0.8}
+                    onPress={() => onPressDate?.(dateKey)}
+                    // style={[
+                    //   styles.dayCell,
+                    //   isSelected && {
+                    //     backgroundColor: colors.selectedBg,
+                    //     borderWidth: 1.5,
+                    //     borderColor: colors.selectedBorder,
+                    //   },
+                    //   !isSelected && isToday && {
+                    //     backgroundColor: colors.todayBg,
+                    //     borderWidth: 1,
+                    //     borderColor: colors.todayBorder,
+                    //   },
+                    // ]}
+                    style={styles.dayCell}
+                >
+                  <View style={styles.dayTop}>
+                      <View
+                          style={[
+                            styles.dayNumberCircle,
+                            isSelected && {
+                              backgroundColor: colors.selectedBg,
+                              borderWidth: 0,
+                            },
+                            !isSelected && isToday && {
+                              backgroundColor: 'transparent',
+                              borderWidth: 1.5,
+                              borderColor: colors.todayBorder,
+                            },
+                          ]}
+                      >
+                      <Text
+                          style={[
+                            styles.dayText,
+                            { color: colors.dayText },
+                            isToday && !isSelected && { color: colors.todayText },
+                            isSelected && { color: colors.selectedText, fontWeight: '800' },
+                          ]}
+                      >
+                        {day}
+                      </Text>
+                    </View>
+                  </View>
+                  <View style={styles.badgeArea}>
+                    {isCompleted ? (
+                        <View
+                            style={[
+                              styles.emojiBadge,
+                              { backgroundColor: colors.badgeBg },
+                            ]}
+                        >
+                          <Text style={styles.emojiText}>{preferredEmoji}</Text>
+                        </View>
+                    ) : (
+                        <View style={styles.badgePlaceholder} />
+                    )}
+                  </View>
+                </TouchableOpacity>
+            );
+          })}
+        </View>
       </View>
-      <View style={styles.grid}>
-        {days.map((day) => {
-          const active = activeDays.has(day);
-          return (
-            <View key={day} style={[styles.cell, active && styles.activeCell]}>
-              <Text style={[styles.dayText, active && styles.activeDayText]}>{day}</Text>
-            </View>
-          );
-        })}
-      </View>
-    </View>
   );
 }
 
 const styles = StyleSheet.create({
-  container: {
-    marginTop: 18,
-    backgroundColor: colors.surface,
+  card: {
     borderRadius: 24,
-    padding: 18,
+    paddingHorizontal: 16,
+    paddingTop: 16,
+    paddingBottom: 12,
+    marginTop: 12,
     borderWidth: 1,
-    borderColor: colors.border
+    shadowColor: '#000',
+    shadowOpacity: 0.04,
+    shadowRadius: 12,
+    shadowOffset: { width: 0, height: 4 },
+    elevation: 2,
   },
-  title: {
-    color: colors.text,
+  headerRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: 14,
+  },
+  headerTitle: {
+    fontSize: 18,
     fontWeight: '800',
-    fontSize: 20,
-    marginBottom: 12
+  },
+  headerSub: {
+    marginTop: 4,
+    fontSize: 12,
+  },
+  headerActions: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+  },
+  iconButton: {
+    width: 32,
+    height: 32,
+    borderRadius: 10,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  iconText: {
+    fontSize: 18,
+    fontWeight: '700',
+  },
+  todayButton: {
+    paddingHorizontal: 10,
+    height: 32,
+    borderRadius: 10,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  todayButtonText: {
+    fontSize: 12,
+    fontWeight: '700',
   },
   weekRow: {
     flexDirection: 'row',
-    justifyContent: 'space-between',
-    marginBottom: 10
+    marginBottom: 6,
   },
-  weekLabel: {
-    width: '14%',
-    color: colors.muted,
+  weekText: {
+    width: `${100 / 7}%`,
     textAlign: 'center',
-    fontWeight: '700'
+    fontSize: 12,
+    fontWeight: '700',
+  },
+  sundayText: {
+    color: '#F08A82',
+  },
+  saturdayText: {
+    color: '#6FA8FF',
   },
   grid: {
     flexDirection: 'row',
     flexWrap: 'wrap',
-    gap: 8
   },
-  cell: {
-    width: '12.6%',
-    aspectRatio: 1,
-    borderRadius: 999,
-    borderWidth: 1,
-    borderColor: '#3c3c3c',
+  dayCell: {
+    width: `${100 / 7}%`,
+    aspectRatio: 0.9,
+    alignItems: 'center',
     justifyContent: 'center',
-    alignItems: 'center'
+    borderRadius: 16,
+    marginBottom: 6,
   },
-  activeCell: {
-    backgroundColor: colors.accent,
-    borderColor: colors.accent
+  emptyCell: {
+    backgroundColor: 'transparent',
+  },
+  dayTop: {
+    height: 22,
+    justifyContent: 'center',
+    alignItems: 'center',
   },
   dayText: {
-    color: colors.text,
-    fontWeight: '700'
+    fontSize: 15,
+    fontWeight: '700',
   },
-  activeDayText: {
-    color: '#111'
-  }
+  badgeArea: {
+    marginTop: 4,
+    minHeight: 22,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  emojiBadge: {
+    minWidth: 24,
+    height: 24,
+    paddingHorizontal: 4,
+    borderRadius: 12,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  emojiText: {
+    fontSize: 13,
+  },
+  badgePlaceholder: {
+    width: 24,
+    height: 24,
+  },
+  dayNumberCircle: {
+    width: 26,
+    height: 26,
+    borderRadius: 12,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
 });

--- a/frontend/src/navigation/RootNavigator.tsx
+++ b/frontend/src/navigation/RootNavigator.tsx
@@ -8,8 +8,12 @@ import HomeScreen from '../screens/HomeScreen';
 import StatsScreen from '../screens/StatsScreen';
 import SettingsScreen from '../screens/SettingsScreen';
 import OnboardingScreen from '../screens/OnboardingScreen';
+import CategoryCreateScreen from '../screens/CategoryCreateScreen';
 
 import { RootStackParamList, MainTabParamList } from '../types/navigation';
+
+import { useFonts } from 'expo-font';
+import { Ionicons } from '@expo/vector-icons';
 
 const Stack = createNativeStackNavigator<RootStackParamList>();
 const Tab = createBottomTabNavigator<MainTabParamList>();
@@ -27,9 +31,14 @@ function MainTabs({ route }: any) {
                     height: 70,
                     paddingBottom: 10,
                     paddingTop: 8,
+                    borderTopWidth: 0,
                 },
                 tabBarActiveTintColor: '#d8c2ff',
                 tabBarInactiveTintColor: '#8b8b8b',
+                tabBarLabelStyle: {
+                    fontSize: 12,
+                    fontWeight: '700',
+                },
             }}
         >
             <Tab.Screen
@@ -52,6 +61,13 @@ function MainTabs({ route }: any) {
 }
 
 export default function RootNavigator() {
+    const [fontsLoaded] = useFonts({
+        ...Ionicons.font,
+    });
+
+    if (!fontsLoaded) {
+        return null;
+    }
     return (
         <Stack.Navigator initialRouteName="Onboarding" screenOptions={{ headerShown: false }}>
             <Stack.Screen name="Onboarding" component={OnboardingScreen} />
@@ -59,6 +75,7 @@ export default function RootNavigator() {
             <Stack.Screen name="Username" component={UsernameScreen} />
             <Stack.Screen name="GoalSetup" component={GoalSetupScreen} />
             <Stack.Screen name="MainTabs" component={MainTabs} />
+            <Stack.Screen name="CategoryCreate" component={CategoryCreateScreen}/>
         </Stack.Navigator>
     );
 }

--- a/frontend/src/screens/CategoryCreateScreen.tsx
+++ b/frontend/src/screens/CategoryCreateScreen.tsx
@@ -1,0 +1,532 @@
+import React, { useState } from 'react';
+import {
+    SafeAreaView,
+    StyleSheet,
+    Text,
+    View,
+    TextInput,
+    TouchableOpacity,
+    ScrollView,
+    Alert,
+} from 'react-native';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { Ionicons } from '@expo/vector-icons';
+import { api } from '../api/client';
+import { STORAGE_KEYS } from '../constants/storage';
+
+export default function CategoryCreateScreen({ navigation }: any) {
+    const [goalTitle, setGoalTitle] = useState('');
+    const [motto, setMotto] = useState('');
+    const [startDate, setStartDate] = useState('');
+    const [endDate, setEndDate] = useState('');
+    const [alarmCycle, setAlarmCycle] = useState<number>(1);
+    const [preferredEmoji, setPreferredEmoji] = useState('🌱');
+    const [characterId, setCharacterId] = useState<number>(1);
+    const [submitting, setSubmitting] = useState(false);
+
+    const emojiOptions = ['🌱', '🔥', '💫', '📚', '🏃‍♂️','🚀'];
+    const [showCustomEmojiInput, setShowCustomEmojiInput] = useState(false);
+    const [customEmojiInput, setCustomEmojiInput] = useState('');
+
+    const cycleOptions = [
+        { label: '매일', value: 1 },
+        { label: '3일마다', value: 3 },
+        { label: '일주일에 1번', value: 7 },
+    ];
+
+    const characterOptions = [
+        { id: 1, emoji: '🐥' },
+        { id: 2, emoji: '🦔' },
+        { id: 3, emoji: '🍦' },
+        { id: 4, emoji: '🥔' },
+        { id: 5, emoji: '🐰' },
+        { id: 6, emoji: '🐯' },
+    ];
+
+    const [showCustomCycleInput, setShowCustomCycleInput] = useState(false);
+    const [alarmInput, setAlarmInput] = useState('');
+
+    const isSingleEmoji = (value: string) => {
+        const trimmed = value.trim();
+        if (!trimmed) return false;
+
+        const emojiRegex = /^(?:\p{Emoji_Presentation}|\p{Emoji}\uFE0F)$/u;
+        return emojiRegex.test(trimmed);
+    };
+
+    const handleSubmit = async () => {
+        try {
+            const userId = await AsyncStorage.getItem(STORAGE_KEYS.USER_ID);
+
+            if (!userId) {
+                Alert.alert('에러', '유저 정보가 없습니다.');
+                return;
+            }
+
+            if (!goalTitle.trim()) {
+                Alert.alert('입력 필요', '목표명을 입력해주세요.');
+                return;
+            }
+
+            if (!startDate.trim() || !endDate.trim()) {
+                Alert.alert('입력 필요', '시작일과 종료일을 입력해주세요.');
+                return;
+            }
+
+            if (showCustomCycleInput && !alarmInput.trim()) {
+                Alert.alert('입력 필요', '직접 입력한 주기를 입력해주세요.');
+                return;
+            }
+
+            if (!alarmCycle || alarmCycle <= 0) {
+                Alert.alert('입력 필요', '올바른 리마인더 주기를 입력해주세요.');
+                return;
+            }
+
+            if (showCustomEmojiInput && !isSingleEmoji(customEmojiInput)) {
+                Alert.alert('입력 필요', '이모지는 1개만 올바르게 입력해주세요.');
+                return;
+            }
+
+            setSubmitting(true);
+
+            const payload = {
+                userId: Number(userId),
+                goalTitle: goalTitle.trim(),
+                motto: motto.trim(),
+                startDate: startDate.trim(),
+                endDate: endDate.trim(),
+                alarmCycle,
+                preferredEmoji,
+                characterId,
+            };
+
+            await api.post('/goals', payload);
+
+            Alert.alert('완료', '카테고리가 등록되었습니다.', [
+                {
+                    text: '확인',
+                    onPress: () => navigation.goBack(),
+                },
+            ]);
+        } catch (e: any) {
+            console.log('카테고리 등록 실패', e);
+            Alert.alert(
+                '에러',
+                e?.response?.data?.message ?? '카테고리 등록 중 오류가 발생했습니다.'
+            );
+        } finally {
+            setSubmitting(false);
+        }
+    };
+
+    return (
+        <SafeAreaView style={styles.container}>
+            <ScrollView
+                contentContainerStyle={styles.content}
+                showsVerticalScrollIndicator={false}
+            >
+                <View style={styles.headerRow}>
+                    <TouchableOpacity
+                        style={styles.backButton}
+                        onPress={() => navigation.goBack()}
+                    >
+                        <Ionicons name="chevron-back" size={20} color="#D8D8DD" />
+                    </TouchableOpacity>
+
+                    <Text style={styles.headerTitle}>카테고리 등록</Text>
+
+                    <View style={styles.headerSpacer} />
+                </View>
+
+                <View style={styles.formCard}>
+                    <Text style={styles.label}>목표명</Text>
+                    <TextInput
+                        style={styles.input}
+                        placeholder="예: 매일 운동하기"
+                        placeholderTextColor="#6E6E73"
+                        value={goalTitle}
+                        onChangeText={setGoalTitle}
+                    />
+
+                    <Text style={styles.label}>다짐</Text>
+                    <TextInput
+                        style={styles.input}
+                        placeholder="한 줄 다짐"
+                        placeholderTextColor="#6E6E73"
+                        value={motto}
+                        onChangeText={setMotto}
+                    />
+
+                    <View style={styles.row}>
+                        <View style={styles.halfBox}>
+                            <Text style={styles.label}>시작일</Text>
+                            <TextInput
+                                style={styles.input}
+                                placeholder="YYYY-MM-DD"
+                                placeholderTextColor="#6E6E73"
+                                value={startDate}
+                                onChangeText={setStartDate}
+                            />
+                        </View>
+
+                        <View style={styles.halfBox}>
+                            <Text style={styles.label}>종료일</Text>
+                            <TextInput
+                                style={styles.input}
+                                placeholder="YYYY-MM-DD"
+                                placeholderTextColor="#6E6E73"
+                                value={endDate}
+                                onChangeText={setEndDate}
+                            />
+                        </View>
+                    </View>
+
+                    <Text style={styles.label}>리마인더 주기</Text>
+                    <View style={styles.chipRow}>
+                        {cycleOptions.map((item) => {
+                            const selected = alarmCycle === item.value && !showCustomCycleInput;
+
+                            return (
+                                <TouchableOpacity
+                                    key={item.value}
+                                    style={[
+                                        styles.cycleChip,
+                                        selected && styles.cycleChipSelected,
+                                    ]}
+                                    onPress={() => {
+                                        setAlarmCycle(item.value);
+                                        setAlarmInput(String(item.value));
+                                        setShowCustomCycleInput(false);
+                                    }}
+                                >
+                                    <Text
+                                        style={[
+                                            styles.cycleChipText,
+                                            selected && styles.cycleChipTextSelected,
+                                        ]}
+                                    >
+                                        {item.label}
+                                    </Text>
+                                </TouchableOpacity>
+                            );
+                        })}
+                        <TouchableOpacity
+                            style={[
+                                styles.cycleChip,
+                                showCustomCycleInput && styles.cycleChipSelected,
+                            ]}
+                            onPress={() => setShowCustomCycleInput((prev) => !prev)}
+                        >
+                            <Text
+                                style={[
+                                    styles.cycleChipText,
+                                    showCustomCycleInput && styles.cycleChipTextSelected,
+                                ]}
+                            >
+                                직접 입력
+                            </Text>
+                        </TouchableOpacity>
+                    </View>
+                    {showCustomCycleInput && (
+                        <View style={styles.customCycleBox}>
+                            <TextInput
+                                style={styles.input}
+                                placeholder="예: 1 (매일)"
+                                placeholderTextColor="#6E6E73"
+                                keyboardType="numeric"
+                                value={alarmInput}
+                                onChangeText={(text) => {
+                                    setAlarmInput(text);
+
+                                    const num = Number(text);
+                                    if (!isNaN(num) && num > 0) {
+                                        setAlarmCycle(num);
+                                    }
+                                }}
+                            />
+                            <Text style={styles.helperText}>
+                                숫자 입력: 1 = 매일, 3 = 3일마다
+                            </Text>
+                        </View>
+                    )}
+
+                    <Text style={styles.label}>이모지</Text>
+                    <View style={styles.emojiRow}>
+                        {emojiOptions.map((emoji) => {
+                            const selected = preferredEmoji === emoji && !showCustomEmojiInput;
+
+                            return (
+                                <TouchableOpacity
+                                    key={emoji}
+                                    style={[
+                                        styles.emojiButton,
+                                        selected && styles.emojiButtonSelected,
+                                    ]}
+                                    onPress={() => {
+                                        setPreferredEmoji(emoji);
+                                        setCustomEmojiInput('');
+                                        setShowCustomEmojiInput(false);
+                                    }}
+                                >
+                                    <Text style={styles.emojiText}>{emoji}</Text>
+                                </TouchableOpacity>
+                            );
+                        })}
+
+                        <TouchableOpacity
+                            style={[
+                                styles.emojiButton,
+                                showCustomEmojiInput && styles.emojiButtonSelected,
+                            ]}
+                            onPress={() => setShowCustomEmojiInput((prev) => !prev)}
+                        >
+                            <Text style={styles.emojiPlusText}>＋</Text>
+                        </TouchableOpacity>
+                    </View>
+
+                    {showCustomEmojiInput && (
+                        <View style={styles.customCycleBox}>
+                            <TextInput
+                                style={styles.input}
+                                placeholder="이모지 1개 입력"
+                                placeholderTextColor="#6E6E73"
+                                value={customEmojiInput}
+                                onChangeText={(text) => {
+                                    setCustomEmojiInput(text);
+
+                                    if (isSingleEmoji(text)) {
+                                        setPreferredEmoji(text.trim());
+                                    }
+                                }}
+                                maxLength={4}
+                            />
+                            <Text style={styles.helperText}>
+                                이모지 1개만 입력할 수 있어요.
+                            </Text>
+                        </View>
+                    )}
+
+                    <Text style={styles.label}>캐릭터</Text>
+                    <View style={styles.characterRow}>
+                        {characterOptions.map((item) => {
+                            const selected = characterId === item.id;
+
+                            return (
+                                <TouchableOpacity
+                                    key={item.id}
+                                    style={[
+                                        styles.characterButton,
+                                        selected && styles.characterButtonSelected,
+                                    ]}
+                                    onPress={() => setCharacterId(item.id)}
+                                >
+                                    <View style={styles.characterEmojiWrap}>
+                                        <Text style={styles.characterEmoji}>{item.emoji}</Text>
+                                    </View>
+                                </TouchableOpacity>
+                            );
+                        })}
+                    </View>
+                </View>
+
+                <TouchableOpacity
+                    style={[styles.submitButton, submitting && styles.submitButtonDisabled]}
+                    onPress={handleSubmit}
+                    disabled={submitting}
+                >
+                    <Text style={styles.submitText}>
+                        {submitting ? '등록 중...' : '등록하기'}
+                    </Text>
+                </TouchableOpacity>
+            </ScrollView>
+        </SafeAreaView>
+    );
+}
+
+const styles = StyleSheet.create({
+    container: {
+        flex: 1,
+        backgroundColor: '#0D0D0D',
+    },
+    content: {
+        paddingHorizontal: 20,
+        paddingTop: 16,
+        paddingBottom: 40,
+    },
+    headerRow: {
+        flexDirection: 'row',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        marginBottom: 22,
+    },
+    backButton: {
+        width: 40,
+        height: 40,
+        borderRadius: 16,
+        backgroundColor: '#17171B',
+        borderWidth: 1,
+        borderColor: 'rgba(255,255,255,0.06)',
+        justifyContent: 'center',
+        alignItems: 'center',
+    },
+    headerTitle: {
+        color: '#EDEDF0',
+        fontSize: 16,
+        fontWeight: '800',
+    },
+    headerSpacer: {
+        width: 40,
+    },
+    formCard: {
+        backgroundColor: '#151518',
+        borderRadius: 28,
+        paddingHorizontal: 16,
+        paddingVertical: 18,
+        borderWidth: 1,
+        borderColor: 'rgba(255,255,255,0.06)',
+    },
+    label: {
+        color: '#8E8E93',
+        fontSize: 13,
+        fontWeight: '700',
+        marginBottom: 8,
+        marginTop: 16,
+    },
+    input: {
+        height: 48,
+        borderRadius: 16,
+        backgroundColor: '#0F0F12',
+        borderWidth: 1,
+        borderColor: 'rgba(255,255,255,0.05)',
+        paddingHorizontal: 14,
+        color: '#F4F4F5',
+        fontSize: 15,
+    },
+    row: {
+        flexDirection: 'row',
+        gap: 12,
+    },
+    halfBox: {
+        flex: 1,
+    },
+    chipRow: {
+        flexDirection: 'row',
+        flexWrap: 'wrap',
+        gap: 8,
+    },
+    cycleChip: {
+        height: 40,
+        paddingHorizontal: 14,
+        borderRadius: 20,
+        backgroundColor: '#0F0F12',
+        borderWidth: 1,
+        borderColor: 'rgba(255,255,255,0.05)',
+        justifyContent: 'center',
+        alignItems: 'center',
+    },
+    cycleChipSelected: {
+        backgroundColor: '#B8F1C6',
+        borderColor: '#C9F7D4',
+    },
+    cycleChipText: {
+        color: '#A1A1AA',
+        fontSize: 13,
+        fontWeight: '700',
+    },
+    cycleChipTextSelected: {
+        color: '#1D3A29',
+    },
+    customCycleBox: {
+        marginTop: 10,
+    },
+    helperText: {
+        marginTop: 6,
+        color: '#7E7E88',
+        fontSize: 12,
+    },
+    emojiRow: {
+        flexDirection: 'row',
+        gap: 10,
+        flexWrap: 'wrap',
+    },
+    emojiButton: {
+        width: 48,
+        height: 48,
+        borderRadius: 16,
+        backgroundColor: '#0F0F12',
+        borderWidth: 1,
+        borderColor: 'rgba(255,255,255,0.05)',
+        justifyContent: 'center',
+        alignItems: 'center',
+    },
+    emojiButtonSelected: {
+        backgroundColor: '#B8F1C6',
+        borderColor: '#C9F7D4',
+    },
+    emojiText: {
+        fontSize: 20,
+    },
+    emojiPlusText: {
+        fontSize: 22,
+        color: '#A1A1AA',
+        fontWeight: '700',
+    },
+    characterRow: {
+        flexDirection: 'row',
+        gap: 10,
+        flexWrap: 'wrap',
+    },
+    characterButton: {
+        width:52,
+        height: 52,
+        borderRadius: 18,
+        backgroundColor: '#0F0F12',
+        borderWidth: 1,
+        borderColor: 'rgba(255,255,255,0.05)',
+        justifyContent: 'center',
+        alignItems: 'center',
+        padding: 0,
+    },
+    characterButtonSelected: {
+        backgroundColor: '#B8F1C6',
+        borderColor: '#C9F7D4',
+        transform: [{scale:1.05}],
+    },
+    characterEmojiWrap:{
+      width: 28,
+      height: 28,
+      justifyContent: 'center',
+      alignItems: 'center',
+    },
+    characterEmoji: {
+        fontSize: 24,
+        lineHeight: 24,
+        textAlign: 'center',
+        includeFontPadding: false,
+    },
+    characterText: {
+        color: '#A1A1AA',
+        fontSize: 13,
+        fontWeight: '700',
+    },
+    characterTextSelected: {
+        color: '#1D3A29',
+    },
+    submitButton: {
+        marginTop: 22,
+        height: 54,
+        borderRadius: 20,
+        backgroundColor: '#B8F1C6',
+        justifyContent: 'center',
+        alignItems: 'center',
+    },
+    submitButtonDisabled: {
+        opacity: 0.6,
+    },
+    submitText: {
+        color: '#1D3A29',
+        fontSize: 16,
+        fontWeight: '800',
+    },
+});

--- a/frontend/src/screens/HomeScreen.tsx
+++ b/frontend/src/screens/HomeScreen.tsx
@@ -1,7 +1,17 @@
-import { useCallback, useState } from 'react';
-import { ScrollView, StyleSheet, Text, RefreshControl } from 'react-native';
+import { useCallback, useEffect, useState } from 'react';
+import {
+    ScrollView,
+    StyleSheet,
+    Text,
+    RefreshControl,
+    View,
+    TouchableOpacity,
+    Modal,
+    Pressable,
+} from 'react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { useFocusEffect } from '@react-navigation/native';
+import { Ionicons } from '@expo/vector-icons';
 
 import CategoryChip from '../components/CategoryChip';
 import MonthlyCalendar from '../components/MonthlyCalendar';
@@ -16,9 +26,10 @@ import type { BottomTabScreenProps } from '@react-navigation/bottom-tabs';
 import { MainTabParamList } from '../types/navigation';
 import { api } from '../api/client';
 
+
 type Props = BottomTabScreenProps<MainTabParamList, 'Home'>;
 
-export default function HomeScreen({ route }: Props) {
+export default function HomeScreen({ navigation,route }: Props) {
     const [username, setUsername] = useState('');
     const [currentLevel, setCurrentLevel] = useState<number | null>(null);
     const [goalPlanId, setGoalPlanId] = useState<number | null>(null);
@@ -26,17 +37,46 @@ export default function HomeScreen({ route }: Props) {
     const [refreshKey, setRefreshKey] = useState(0);
     const [characterImageUrl, setCharacterImageUrl] = useState<string | undefined>();
 
+    const [completedDates, setCompletedDates] = useState<string[]>([]);
+    const [preferredEmoji, setPreferredEmoji] = useState('🌱');
+
+    const [motto, setMotto] = useState('');
+
+    const today = new Date();
+
+    const [year, setYear] = useState(today.getFullYear());
+    const [month, setMonth] = useState(today.getMonth() + 1);
+
+    //사용자가 누른 날짜 강조 표시
+    const [selectedDate, setSelectedDate] = useState(
+        `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, '0')}-${String(today.getDate()).padStart(2, '0')}`
+    );
+
+    const [menuVisible, setMenuVisible] = useState(false);
+
     const loadData = async () => {
-        const savedUsername = await AsyncStorage.getItem(STORAGE_KEYS.USERNAME);
-        const savedGoalPlanId = await AsyncStorage.getItem(STORAGE_KEYS.GOAL_PLAN_ID);
-        const savedUserId = await AsyncStorage.getItem(STORAGE_KEYS.USER_ID);
+        try {
+            const savedUsername = await AsyncStorage.getItem(STORAGE_KEYS.USERNAME);
+            const savedGoalPlanId = await AsyncStorage.getItem(STORAGE_KEYS.GOAL_PLAN_ID);
+            const savedUserId = await AsyncStorage.getItem(STORAGE_KEYS.USER_ID);
 
-        if (savedUsername) setUsername(savedUsername);
-        if (savedGoalPlanId) setGoalPlanId(Number(savedGoalPlanId));
+            if (savedUsername) setUsername(savedUsername);
+            if (savedGoalPlanId) {
+                const goalId = Number(savedGoalPlanId);
 
-        if (savedUserId) {
-            const uid = Number(savedUserId);
-            await fetchCharacter(uid);
+                setGoalPlanId(goalId);
+
+                const res = await api.get(`/goals/${goalId}`);
+
+                setMotto(res.data.motto ?? '');
+            }
+
+            if (savedUserId) {
+                const uid = Number(savedUserId);
+                await fetchCharacter(uid);
+            }
+        } catch (e) {
+            console.log('loadData error:', e);
         }
     };
 
@@ -46,20 +86,43 @@ export default function HomeScreen({ route }: Props) {
         }, [])
     );
 
+    useEffect(() => {
+        const fetchCalendar = async () => {
+            try {
+                if (!goalPlanId) return;
+
+                const res = await api.get(`/goal-plans/${goalPlanId}/calendar`, {
+                    params: {
+                        year,
+                        month,
+                    },
+                });
+
+                setCompletedDates(res.data.completedDates ?? []);
+                setPreferredEmoji(res.data.preferredEmoji ?? '🌱');
+
+            } catch (e) {
+                console.log('달력 조회 실패:', e);
+                setCompletedDates([]);
+                setPreferredEmoji('🌱');
+            }
+        };
+
+        fetchCalendar();
+    }, [goalPlanId, year, month, refreshKey]);
+
     const onRefresh = async () => {
         setRefreshing(true);
         await loadData();
-        setRefreshKey((prev) => prev + 1); // ⭐ 강제 리렌더
+        setRefreshKey((prev) => prev + 1);
         setRefreshing(false);
     };
 
     const fetchCharacter = async (uid: number) => {
         try {
             if (!uid) return;
-            const res = await api.get(
-                `/characters/current?userId=${uid}`
-            );
 
+            const res = await api.get(`/characters/current?userId=${uid}`);
             setCharacterImageUrl(res.data.imageUrl);
             setCurrentLevel(res.data.level);
         } catch (e) {
@@ -67,44 +130,148 @@ export default function HomeScreen({ route }: Props) {
         }
     };
 
+    const goPrevMonth = () => {
+        if (month === 1) {
+            setYear(year - 1);
+            setMonth(12);
+        } else {
+            setMonth(month - 1);
+        }
+    };
+
+    const goNextMonth = () => {
+        if (month === 12) {
+            setYear(year + 1);
+            setMonth(1);
+        } else {
+            setMonth(month + 1);
+        }
+    };
+
+    const goTodayMonth = () => {
+        const now = new Date();
+        const todayKey = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(now.getDate()).padStart(2, '0')}`;
+
+        setYear(now.getFullYear());
+        setMonth(now.getMonth() + 1);
+        setSelectedDate(todayKey);
+    };
+    const handleCategoryCreate = () => {
+        setMenuVisible(false);
+        navigation.navigate('CategoryCreate');
+    };
+
+    const handleCategoryManage = () => {
+        setMenuVisible(false);
+        console.log('카테고리 관리');
+        // navigation.navigate('CategoryManage');
+    };
+
+    const handleReminderManage = () => {
+        setMenuVisible(false);
+        console.log('리마인더 관리');
+        // navigation.navigate('ReminderManage');
+    };
     return (
-        <ScrollView
-            style={styles.container}
-            contentContainerStyle={styles.content}
-            refreshControl={
-                <RefreshControl refreshing={refreshing} onRefresh={onRefresh} />
-            }
-        >
-            <Text style={styles.title}>
-                {username ? `${username}님, 오늘도 한 칸 전진` : '오늘도 한 칸 전진'}
-            </Text>
+        <>
+            <ScrollView
+                style={styles.container}
+                contentContainerStyle={styles.content}
+                refreshControl={
+                    <RefreshControl refreshing={refreshing} onRefresh={onRefresh} />
+                }
+            >
+                <View style={styles.headerRow}>
+                    <View style={styles.headerTextBox}>
+                        <Text style={styles.title}>
+                            {username ? `${username}님, ${motto || '오늘도 한 칸 전진'}`
+                                : motto || '오늘도 한 칸 전진'}
+                        </Text>
+                        <Text style={styles.subtitle}>
+                            {mockSummary.streak}일째 루틴 이어가는 중
+                        </Text>
+                    </View>
 
-            <Text style={styles.subtitle}>
-                {mockSummary.streak}일째 루틴 이어가는 중
-            </Text>
+                    <TouchableOpacity
+                        style={styles.menuButton}
+                        onPress={() => setMenuVisible(true)}
+                    >
+                        <Ionicons name="menu" size={24} color="#FFFFFF" />
+                    </TouchableOpacity>
+                </View>
 
-            <ScrollView horizontal showsHorizontalScrollIndicator={false} style={styles.chipRow}>
-                {mockCategories.map((category) => (
-                    <CategoryChip key={category.id} category={category} />
-                ))}
+                <ScrollView
+                    horizontal
+                    showsHorizontalScrollIndicator={false}
+                    style={styles.chipRow}
+                >
+                    {mockCategories.map((category) => (
+                        <CategoryChip key={category.id} category={category} />
+                    ))}
+                </ScrollView>
+
+                <PixelCard
+                    message={currentLevel === null ? '불러오는 중...' : `현재 성장 단계 Lv.${currentLevel} / 10`}
+                    avatarUrl={characterImageUrl}
+                />
+
+                <MonthlyCalendar
+                    year={year}
+                    month={month}
+                    completedDates={completedDates}
+                    preferredEmoji={preferredEmoji}
+                    onPrevMonth={goPrevMonth}
+                    onNextMonth={goNextMonth}
+                    onPressToday={goTodayMonth}
+                    selectedDate={selectedDate}
+                    onPressDate={setSelectedDate}
+                />
+
+                {goalPlanId && (
+                    <DailyTaskSection
+                        goalPlanId={goalPlanId}
+                        onLevelChange={setCurrentLevel}
+                        refreshKey={refreshKey}
+                        onLevelUp={fetchCharacter}
+                        onTasksUpdated={() => setRefreshKey((prev) => prev + 1)}
+                    />
+                )}
             </ScrollView>
 
-            <PixelCard
-                message={currentLevel === null ? '불러오는 중...' : `현재 성장 단계 Lv.${currentLevel} / 10`}
-                avatarUrl={characterImageUrl}
-            />
+            <Modal
+                visible={menuVisible}
+                transparent
+                animationType="fade"
+                onRequestClose={() => setMenuVisible(false)}
+            >
+                <Pressable style={styles.dropdownOverlay} onPress={() => setMenuVisible(false)}>
+                    <View style={styles.dropdownWrapper}>
+                        <Pressable style={styles.dropdownMenu} onPress={() => {}}>
+                            <View style={styles.menuHeader}>
+                                <Text style={styles.menuHeaderTitle}>메뉴</Text>
+                                <TouchableOpacity onPress={() => setMenuVisible(false)}>
+                                    <Ionicons name="close" size={22} color="#FFFFFF" />
+                                </TouchableOpacity>
+                            </View>
+                            <TouchableOpacity style={styles.menuItem} onPress={handleCategoryCreate}>
+                                <Ionicons name="add-circle-outline" size={18} color="#FFFFFF" />
+                                <Text style={styles.menuItemText}>카테고리 등록</Text>
+                            </TouchableOpacity>
 
-            <MonthlyCalendar />
+                            <TouchableOpacity style={styles.menuItem} onPress={handleCategoryManage}>
+                                <Ionicons name="grid-outline" size={18} color="#FFFFFF" />
+                                <Text style={styles.menuItemText}>카테고리 관리</Text>
+                            </TouchableOpacity>
 
-            {goalPlanId && (
-                <DailyTaskSection
-                    goalPlanId={goalPlanId}
-                    onLevelChange={setCurrentLevel}
-                    refreshKey={refreshKey}
-                    onLevelUp={fetchCharacter}
-                />
-            )}
-        </ScrollView>
+                            <TouchableOpacity style={styles.menuItem} onPress={handleReminderManage}>
+                                <Ionicons name="notifications-outline" size={18} color="#FFFFFF" />
+                                <Text style={styles.menuItemText}>리마인더 관리</Text>
+                            </TouchableOpacity>
+                        </Pressable>
+                    </View>
+                </Pressable>
+            </Modal>
+        </>
     );
 }
 
@@ -117,6 +284,15 @@ const styles = StyleSheet.create({
         paddingHorizontal: 20,
         paddingTop: 64,
         paddingBottom: 120,
+    },
+    headerRow: {
+        flexDirection: 'row',
+        justifyContent: 'space-between',
+        alignItems: 'flex-start',
+    },
+    headerTextBox: {
+        flex: 1,
+        paddingRight: 12,
     },
     title: {
         color: colors.text,
@@ -137,5 +313,108 @@ const styles = StyleSheet.create({
         fontWeight: '700',
         marginTop: 14,
         marginBottom: 12,
+    },
+    calendarHeaderRow: {
+        marginTop: 16,
+        marginBottom: 8,
+        flexDirection: 'row',
+        justifyContent: 'space-between',
+        alignItems: 'center',
+    },
+    monthButton: {
+        width: 40,
+        height: 40,
+        borderRadius: 12,
+        backgroundColor: '#FFFFFF',
+        justifyContent: 'center',
+        alignItems: 'center',
+    },
+    dropdownOverlay: {
+        flex: 1,
+        backgroundColor: 'rgba(0,0,0,0.35)',
+    },
+    modalBackdrop: {
+        flex: 1,
+    },
+    menuButton: {
+        width: 42,
+        height: 42,
+        borderRadius: 14,
+        backgroundColor: '#1E1E22',
+        justifyContent: 'center',
+        alignItems: 'center',
+        marginTop: 2,
+    },
+    dropdownWrapper: {
+        position: 'absolute',
+        top: 105,
+        right: 20,
+    },
+    dropdownMenu: {
+        width: 210,
+        backgroundColor: '#151518',
+        borderRadius: 20,
+        paddingTop: 8,
+        paddingBottom: 6,
+        paddingHorizontal: 14,
+        borderWidth: 1,
+        borderColor: '#26262B',
+        shadowColor: '#000',
+        shadowOpacity: 0.18,
+        shadowRadius: 12,
+        shadowOffset: { width: 0, height: 6 },
+        elevation: 8,
+    },
+
+    dropdownItem: {
+        paddingVertical: 14,
+        paddingHorizontal: 16,
+    },
+
+    dropdownItemText: {
+        color: '#F5F5F5',
+        fontSize: 15,
+        fontWeight: '700',
+    },
+    menuHeader: {
+        flexDirection: 'row',
+        justifyContent: 'space-between',
+        alignItems: 'center',
+        paddingHorizontal: 4,
+        paddingTop: 6,
+        paddingBottom: 10,
+    },
+    menuHeaderTitle: {
+        color: '#FFFFFF',
+        fontSize: 16,
+        fontWeight: '800',
+    },
+    menuItem: {
+        flexDirection: 'row',
+        alignItems: 'center',
+        gap: 10,
+        paddingVertical: 14,
+        paddingHorizontal: 4,
+    },
+    menuItemText: {
+        color: '#F5F5F5',
+        fontSize: 15,
+        fontWeight: '700',
+    },
+    monthButtonText: {
+        fontSize: 18,
+        fontWeight: '700',
+        color: colors.text,
+    },
+    todayButton: {
+        paddingHorizontal: 14,
+        paddingVertical: 8,
+        borderRadius: 12,
+        backgroundColor: '#FFFFFF',
+    },
+    todayButtonText: {
+        fontSize: 14,
+        fontWeight: '700',
+        color: colors.text,
     },
 });

--- a/frontend/src/screens/InitScreen.tsx
+++ b/frontend/src/screens/InitScreen.tsx
@@ -7,7 +7,7 @@ import { STORAGE_KEYS } from '../constants/storage';
 
 type Props = NativeStackScreenProps<RootStackParamList, 'Init'>;
 
-const BASE_URL = 'http://localhost:8080';
+const BASE_URL = 'http://172.20.1.227:8080/api';
 
 type StatusResponse = {
     userId: number;
@@ -26,11 +26,9 @@ export default function InitScreen({ navigation }: Props) {
     useEffect(() => {
         const init = async () => {
             try {
-                console.log('InitScreen 시작');
                 let userId = await AsyncStorage.getItem(STORAGE_KEYS.USER_ID);
-                console.log('저장된 userId:', userId);
                 if (!userId) {
-                    const guestResponse = await fetch(`${BASE_URL}/api/users/guest`, {
+                    const guestResponse = await fetch(`${BASE_URL}/users/guest`, {
                         method: 'POST',
                     });
 
@@ -45,7 +43,7 @@ export default function InitScreen({ navigation }: Props) {
                 }
 
                 const statusResponse = await fetch(
-                    `${BASE_URL}/api/onboarding/status?userId=${userId}`
+                    `${BASE_URL}/onboarding/status?userId=${userId}`
                 );
 
                 if (!statusResponse.ok) {

--- a/frontend/src/screens/OnboardingScreen.tsx
+++ b/frontend/src/screens/OnboardingScreen.tsx
@@ -23,11 +23,21 @@ import type { CycleOption, Step } from '../types/onboarding';
 import { useNavigation } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import type { RootStackParamList } from '../types/navigation';
-import AsyncStorage from "@react-native-async-storage/async-storage";
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import { STORAGE_KEYS } from '../constants/storage';
+
 type NavigationProp = NativeStackNavigationProp<RootStackParamList>;
 
 const cycleOptions: CycleOption[] = ['매일', '주 3회', '주 5회'];
+const emojiOptions = ['🌱', '🔥', '💫', '📚', '🏃‍♂️','🚀'];
+const characterOptions = [
+    { id: 1, emoji: '🐥' },
+    { id: 2, emoji: '🦔' },
+    { id: 3, emoji: '🍦' },
+    { id: 4, emoji: '🥔' },
+    { id: 5, emoji: '🐰' },
+    { id: 6, emoji: '🐯' },
+];
 
 export default function OnboardingScreen() {
     const navigation = useNavigation<NavigationProp>();
@@ -41,27 +51,46 @@ export default function OnboardingScreen() {
     const [nicknameMessage, setNicknameMessage] = useState('');
 
     const [goalTitle, setGoalTitle] = useState('');
+    const [motto, setMotto] = useState('');
     const [deadline, setDeadline] = useState('2026-04-30');
     const [cycle, setCycle] = useState<CycleOption>('주 5회');
+    const [preferredEmoji, setPreferredEmoji] = useState('🌱');
     const [characterName, setCharacterName] = useState('');
 
     const [loading, setLoading] = useState(false);
     const [submitLoading, setSubmitLoading] = useState(false);
-    const progressText = useMemo(() => `${Math.min(step, 6)}/6`, [step]);
-    const progressWidth = useMemo<DimensionValue>(
-        () => `${(Math.min(step, 6) / 6) * 100}%`,
+
+    const [showCustomEmojiInput, setShowCustomEmojiInput] = useState(false);
+    const [customEmojiInput, setCustomEmojiInput] = useState('');
+
+    const [characterId, setCharacterId] = useState<number | null>(1);
+
+    const totalSteps = 8;
+
+    const progressText = useMemo(
+        () => `${Math.min(step, totalSteps)}/${totalSteps}`,
         [step]
     );
 
-    const canGoNickname = nickname.trim() !== '' && nicknameChecked && nicknameAvailable === true;
+    const progressWidth = useMemo<DimensionValue>(
+        () => `${(Math.min(step, totalSteps) / totalSteps) * 100}%`,
+        [step]
+    );
+
+    const canGoNickname =
+        nickname.trim() !== '' && nicknameChecked && nicknameAvailable === true;
     const canGoGoalTitle = goalTitle.trim() !== '';
+    const canGoMotto = motto.trim() !== '';
     const canGoDeadline = deadline.trim() !== '';
     const canGoCycle = cycle.trim() !== '';
-    const canComplete = characterName.trim() !== '';
+    const canGoEmoji = showCustomEmojiInput
+        ? customEmojiInput.trim() !== ''
+        : preferredEmoji.trim() !== '';
+    const canComplete = characterName.trim() !== '' && characterId !== null;
 
     const goNext = () =>
         setStep((prev) => {
-            if (prev === 6) return 6;
+            if (prev === totalSteps) return totalSteps as Step;
             return (prev + 1) as Step;
         });
 
@@ -70,6 +99,7 @@ export default function OnboardingScreen() {
             if (prev === 1) return 1;
             return (prev - 1) as Step;
         });
+
     const handleNicknameChange = (value: string) => {
         setNickname(value);
         setNicknameChecked(false);
@@ -77,6 +107,18 @@ export default function OnboardingScreen() {
         setNicknameMessage('');
     };
 
+    const handleEmojiNext = () => {
+        if (showCustomEmojiInput) {
+            if (!isSingleEmoji(customEmojiInput)) {
+                Alert.alert('입력 필요', '이모지는 1개만 올바르게 입력해주세요.');
+                return;
+            }
+
+            setPreferredEmoji(customEmojiInput.trim());
+        }
+
+        goNext();
+    };
     const cycleToNumber = (cycle: CycleOption): number => {
         switch (cycle) {
             case '매일':
@@ -91,14 +133,9 @@ export default function OnboardingScreen() {
     };
 
     const handleStart = async () => {
-        console.log('🔥 시작하기 버튼 클릭됨');
         try {
             setLoading(true);
-            console.log('📡 createGuestUser 호출 직전');
             const data = await createGuestUser();
-
-            console.log('✅ createGuestUser 성공 응답:', data);
-
             setUserId(data.userId);
             goNext();
         } catch (error) {
@@ -142,7 +179,6 @@ export default function OnboardingScreen() {
                 userId,
                 username: nickname.trim(),
             });
-            console.log('📡nickname 변경 완료 : ' + nickname);
             goNext();
         } catch (error) {
             console.error(error);
@@ -150,6 +186,14 @@ export default function OnboardingScreen() {
         } finally {
             setLoading(false);
         }
+    };
+
+    const isSingleEmoji = (value: string) => {
+        const trimmed = value.trim();
+        if (!trimmed) return false;
+
+        const emojiRegex = /^(?:\p{Emoji_Presentation}|\p{Emoji}\uFE0F)$/u;
+        return emojiRegex.test(trimmed);
     };
 
     const handleComplete = async () => {
@@ -160,22 +204,30 @@ export default function OnboardingScreen() {
             return;
         }
 
+        if (showCustomEmojiInput && !isSingleEmoji(customEmojiInput)) {
+            Alert.alert('입력 필요', '이모지는 1개만 올바르게 입력해주세요.');
+            return;
+        }
+        if (!characterId) {
+            Alert.alert('입력 필요', '캐릭터를 선택해주세요.');
+            return;
+        }
+
         try {
             setSubmitLoading(true);
 
             const onboardingResult = await setupOnboarding({
                 userId,
                 goalTitle: goalTitle.trim(),
-                motto: `${goalTitle.trim()} 꾸준히 달성하기`,
-                characterId: 1,
+                motto: motto.trim(),
+                characterId,
                 characterName: characterName.trim(),
                 startDate: new Date().toISOString().slice(0, 10),
                 endDate: deadline,
                 alarmCycle: cycleToNumber(cycle),
-                preferredEmoji: '🌱',
+                preferredEmoji,
             });
 
-            console.log('✅ onboarding 완료:', onboardingResult);
 
             await AsyncStorage.setItem(
                 STORAGE_KEYS.GOAL_PLAN_ID,
@@ -201,12 +253,7 @@ export default function OnboardingScreen() {
                     },
                 ],
             });
-
         } catch (error: any) {
-            console.log('🔥 setup error status:', error.response?.status);
-            console.log('🔥 setup error data:', error.response?.data);
-            console.log('🔥 setup error message:', error.message);
-
             Alert.alert('설정 완료 실패', error.message);
         } finally {
             setSubmitLoading(false);
@@ -230,7 +277,7 @@ export default function OnboardingScreen() {
                             <View style={styles.startInfoCard}>
                                 <Text style={styles.startInfoTitle}>온보딩에서 정할 것</Text>
                                 <Text style={styles.startInfoText}>
-                                    별명 · 목표 이름 · 마감일 · 목표 주기 · 캐릭터 이름
+                                    별명 · 목표 이름 · 모토 · 마감일 · 목표 주기 · 이모지 · 캐릭터 이름
                                 </Text>
                             </View>
                         </View>
@@ -238,7 +285,6 @@ export default function OnboardingScreen() {
                         <View style={styles.footer}>
                             <PrimaryButton label="시작하기" loading={loading} onPress={handleStart} />
 
-                            {/* 테스트 계정들어가기 나중에 삭제할 것 */}
                             <Pressable
                                 style={[styles.button, { backgroundColor: '#444', marginTop: 10 }]}
                                 onPress={async () => {
@@ -331,6 +377,22 @@ export default function OnboardingScreen() {
                         stepText={progressText}
                         progressWidth={progressWidth}
                         onBack={goPrev}
+                        title="모토를 적어주세요"
+                        subtitle="목표를 이어가게 도와주는 한 문장을 적어보세요."
+                        footer={<PrimaryButton label="다음으로" disabled={!canGoMotto} onPress={goNext} />}
+                    >
+                        <FloatingField
+                            label="모토"
+                            value={motto}
+                            onChangeText={setMotto}
+                            placeholder="예: 포기하지 않고 끝까지"
+                        />
+                    </StepLayout>
+                ) : step === 5 ? (
+                    <StepLayout
+                        stepText={progressText}
+                        progressWidth={progressWidth}
+                        onBack={goPrev}
                         title="마감일을 정해주세요"
                         subtitle="지금은 문자열 입력으로 두고, 나중에 DatePicker로 바꾸면 돼요."
                         footer={<PrimaryButton label="다음으로" disabled={!canGoDeadline} onPress={goNext} />}
@@ -342,7 +404,7 @@ export default function OnboardingScreen() {
                             placeholder="YYYY-MM-DD"
                         />
                     </StepLayout>
-                ) : step === 5 ? (
+                ) : step === 6 ? (
                     <StepLayout
                         stepText={progressText}
                         progressWidth={progressWidth}
@@ -367,7 +429,58 @@ export default function OnboardingScreen() {
                             })}
                         </View>
                     </StepLayout>
-                ) : step === 6 ? (
+                ) : step === 7 ? (
+                    <StepLayout
+                        stepText={progressText}
+                        progressWidth={progressWidth}
+                        onBack={goPrev}
+                        title="대표 이모지를 골라주세요"
+                        subtitle="달력에 표시될 이모지예요."
+                        footer={<PrimaryButton label="다음으로" disabled={!canGoEmoji} onPress={handleEmojiNext} />}
+                    >
+                        <View style={styles.emojiGrid}>
+                            {emojiOptions.map((emoji) => {
+                                const selected = preferredEmoji === emoji && !showCustomEmojiInput;
+
+                                return (
+                                    <Pressable
+                                        key={emoji}
+                                        onPress={() => {
+                                            setPreferredEmoji(emoji);
+                                            setCustomEmojiInput('');
+                                            setShowCustomEmojiInput(false);
+                                        }}
+                                        style={[styles.emojiCard, selected && styles.emojiCardSelected]}
+                                    >
+                                        <Text style={styles.emojiValue}>{emoji}</Text>
+                                    </Pressable>
+                                );
+                            })}
+
+                            <Pressable
+                                onPress={() => setShowCustomEmojiInput((prev) => !prev)}
+                                style={[styles.emojiCard, showCustomEmojiInput && styles.emojiCardSelected]}
+                            >
+                                <Text style={styles.emojiPlus}>＋</Text>
+                            </Pressable>
+                        </View>
+
+                        {showCustomEmojiInput && (
+                            <View style={styles.customEmojiBox}>
+                                <FloatingField
+                                    label="직접 이모지 입력"
+                                    value={customEmojiInput}
+                                    onChangeText={setCustomEmojiInput}
+                                    placeholder="이모지 1개 입력"
+                                />
+
+                                <Text style={styles.helperText}>
+                                    이모지 1개만 입력할 수 있어요.
+                                </Text>
+                            </View>
+                        )}
+                    </StepLayout>
+                ) : step === 8 ? (
                     <StepLayout
                         stepText={progressText}
                         progressWidth={progressWidth}
@@ -383,9 +496,25 @@ export default function OnboardingScreen() {
                             />
                         }
                     >
-                        <View style={styles.characterCard}>
-                            <Text style={styles.characterEmoji}>🐣</Text>
-                            <Text style={styles.characterHint}>아직 작은 알 상태예요</Text>
+                        <View style={styles.characterGrid}>
+                            {characterOptions.map((item) => {
+                                const selected = characterId === item.id;
+
+                                return (
+                                    <Pressable
+                                        key={item.id}
+                                        onPress={() => setCharacterId(item.id)}
+                                        style={[
+                                            styles.characterSelectCard,
+                                            selected && styles.characterSelectCardSelected,
+                                        ]}
+                                    >
+                                        <View style={styles.characterEmojiWrap}>
+                                            <Text style={styles.characterSelectEmoji}>{item.emoji}</Text>
+                                        </View>
+                                    </Pressable>
+                                );
+                            })}
                         </View>
 
                         <FloatingField
@@ -494,17 +623,94 @@ const styles = StyleSheet.create({
         fontWeight: '600',
         color: '#171717',
     },
-    characterCard: {
-        borderRadius: 28,
-        backgroundColor: '#fffbeb',
-        borderWidth: 1,
-        borderColor: '#fde68a',
-        paddingVertical: 28,
-        alignItems: 'center',
+    emojiGrid: {
+        flexDirection: 'row',
+        flexWrap: 'wrap',
         justifyContent: 'center',
+        gap: 14,
     },
-    characterEmoji: {
-        fontSize: 72,
+    emojiCard: {
+        width: 72,
+        height: 72,
+        borderRadius: 20,
+        borderWidth: 1,
+        borderColor: '#e5e5e5',
+        backgroundColor: '#ffffff',
+
+        justifyContent: 'center',  // ⭐
+        alignItems: 'center',      // ⭐
+    },
+    emojiCardSelected: {
+        borderColor: '#86efac',
+        backgroundColor: '#f0fdf4',
+    },
+    emojiValue: {
+        fontSize: 28,
+        lineHeight: 30,
+        textAlign: 'center',
+    },
+    emojiPlus: {
+        fontSize: 26,
+        color: '#6b7280',
+        fontWeight: '700',
+    },
+
+    customEmojiBox: {
+        marginTop: 14,
+    },
+
+    helperText: {
+        marginTop: 8,
+        fontSize: 12,
+        color: '#737373',
+    },
+    // characterCard: {
+    //     borderRadius: 28,
+    //     backgroundColor: '#fffbeb',
+    //     borderWidth: 1,
+    //     borderColor: '#fde68a',
+    //     paddingVertical: 28,
+    //     alignItems: 'center',
+    //     justifyContent: 'center',
+    // },
+    // characterEmoji: {
+    //     fontSize: 72,
+    // },
+    characterGrid: {
+        flexDirection: 'row',
+        flexWrap: 'wrap',
+        justifyContent: 'center',
+        gap: 12,
+    },
+
+    characterSelectCard: {
+        width: 72,
+        height: 72,
+        borderRadius: 22,
+        borderWidth: 1,
+        borderColor: '#e5e5e5',
+        backgroundColor: '#ffffff',
+        justifyContent: 'center',
+        alignItems: 'center',
+    },
+
+    characterSelectCardSelected: {
+        borderColor: '#86efac',
+        backgroundColor: '#f0fdf4',
+        transform: [{ scale: 1.03 }],
+    },
+
+    characterEmojiWrap: {
+        width: 32,
+        height: 32,
+        justifyContent: 'center',
+        alignItems: 'center',
+    },
+
+    characterSelectEmoji: {
+        fontSize: 28,
+        lineHeight: 30,
+        textAlign: 'center',
     },
     characterHint: {
         marginTop: 8,
@@ -541,7 +747,6 @@ const styles = StyleSheet.create({
         justifyContent: 'center',
         alignItems: 'center',
     },
-
     buttonText: {
         color: '#fff',
         fontSize: 15,

--- a/frontend/src/types/navigation.ts
+++ b/frontend/src/types/navigation.ts
@@ -4,6 +4,7 @@ export type RootStackParamList = {
     Username: { userId: number };
     GoalSetup: { userId: number };
     MainTabs: { userId: number };
+    CategoryCreate: undefined;
 };
 
 export type MainTabParamList = {

--- a/frontend/src/types/onboarding.ts
+++ b/frontend/src/types/onboarding.ts
@@ -1,4 +1,4 @@
-export type Step = 1 | 2 | 3 | 4 | 5 | 6 | 7;
+export type Step = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8;
 export type CycleOption = '매일' | '주 3회' | '주 5회' | '평일';
 
 export type GuestUserResponse = {


### PR DESCRIPTION
# 아래 내용은 예시이니 해당하는 내용만 남긴 후 작성해주세요.

### 🚀 작업 요약
- 예: 주기별 체크리스트 자동 생성 로직 및 달성률 조회 API 구현

### 🛠️ 주요 변경 사항
#### 1. Backend (Spring Boot)
- [x] **Entity/Repository**: 
- [x] GoalDefinition에 motto 필드 활용 및 연동 
- [x] 목표 생성 시 Definition / Plan / Config 분리 구조 적용
- [x] DailyTaskRepository에 완료일 조회 쿼리 추가 및 findCompletedDatesByGoalPlanId 추가
- [x] **Service/Controller**: 
- [x] GoalPlanService.createGoalPlan() 로직 분리 (온보딩 의존 제거)
- [x] GoalPlanService.getGoal(Long goalId) 단건 조회 API 추가
- [x] GoalPlanResponse에 motto 필드 추가 및 DTO 매핑 수정
- [x] **API Endpoint**: 
- [x] GET /api/goals/{goalId} 추가 (홈 화면용 단건 조회 추가)
- [x] GET /api/goal-plans/{goalPlanId}/calendar (달력 조회 추가)

#### 2. Frontend (React Native)
- [x] **Logic**: 홈 화면에서 /goals/{goalId} 호출하여 motto 세팅
- [x] **UI/UX**: 온보딩 화면 개선 / 이모지 선택 + 직접 입력 기능 추가 / 캐릭터 선택 UI 추가 (grid 형태) / 홈 화면 문구 개선(username + motto 기반 동적 문구 적용) / 캘린더를 사용자 기준 → goalPlan 기준으로 변경 / 햄버거 모달 추가 / 모달 메뉴 구성 / 카테고리 등록 화면 구성


### ⚠️ 리뷰어(@seorivn ) 전달 사항
- **주의**: 서비스단에서 선택한 월 기준으로 달성된 일자만 `dailyTaskRepository`를 통해 조회하도록 수정하였습니다.  
프론트에서는 해당 데이터를 `completedDates` 상태로 받아 캘린더에 표시하도록 처리하였습니다.  
관련 로직은 HomeScreen.tsx에서 completedDates 상태를 관리하고 캘린더에 반영하는 부분인  89~109 line에 구현되어 있습니다. 
알람(리마인더)시간은 테이블 수정 작업이 필요하여 아직 구현하지 않았으며 카테고리 수정 및 리마인더 관리 또한, 아직 구현하지 못했습니다. 따라서 셋팅 화면 내 기존에 존재하던 수정 로직은 그대로 살려두었으나 추후 21일에 작업 후 삭제처리하도록 하겠습니다.