### PR TITLE
feat: 카테고리 기준 데이터 조회 흐름 개편 및 목표/통계 연동 개선

### DIFF
--- a/backend/src/main/java/com/example/focusapp/controller/CharacterController.java
+++ b/backend/src/main/java/com/example/focusapp/controller/CharacterController.java
@@ -19,13 +19,13 @@ public class CharacterController {
 
     @GetMapping("/current")
     public ResponseEntity<CharacterResponse> getCurrentCharacter(
-            @RequestParam Long userId
+            @RequestParam Long goalPlanId
     ) {
         return ResponseEntity.ok(
-                characterService.getCurrentCharacter(userId)
+                characterService.getCurrentCharacterByGoalPlan(goalPlanId)
         );
     }
-
+    
     @GetMapping
     public ResponseEntity<List<CharacterListResponse>> getCharacters() {
         return ResponseEntity.ok(characterService.getAllCharacters());

--- a/backend/src/main/java/com/example/focusapp/controller/DailyTaskController.java
+++ b/backend/src/main/java/com/example/focusapp/controller/DailyTaskController.java
@@ -25,13 +25,17 @@ public class DailyTaskController {
     private final GoalPlanRepository goalPlanRepository;
 
     @GetMapping("/active/{goalPlanId}")
-    public List<DailyTaskResponse> getTodayTasks(@PathVariable Long goalPlanId) {
-
+    public List<DailyTaskResponse> getTasksByDate(
+            @PathVariable Long goalPlanId,
+            @RequestParam String date
+    ) {
         GoalPlan goalPlan = goalPlanRepository.findById(goalPlanId)
                 .orElseThrow(() -> new NotFoundException("GoalPlan 없음"));
 
+        LocalDate targetDate = LocalDate.parse(date);
+
         List<DailyTask> tasks =
-                dailyTaskService.getTodayTasks(goalPlan, LocalDate.now());
+                dailyTaskService.getTodayTasks(goalPlan, targetDate);
 
         return tasks.stream()
                 .map(task -> new DailyTaskResponse(
@@ -43,7 +47,6 @@ public class DailyTaskController {
                 ))
                 .toList();
     }
-
     @PatchMapping("/{id}/toggle")
     public ResponseEntity<DailyTaskResponse> toggle(@PathVariable Long id) {
         return ResponseEntity.ok(dailyTaskService.toggle(id));

--- a/backend/src/main/java/com/example/focusapp/controller/GoalResultController.java
+++ b/backend/src/main/java/com/example/focusapp/controller/GoalResultController.java
@@ -1,64 +1,37 @@
 package com.example.focusapp.controller;
 
 import com.example.focusapp.dto.GoalResultResponse;
-import com.example.focusapp.entity.GoalPlan;
-import com.example.focusapp.entity.User;
-import com.example.focusapp.exception.NotFoundException;
-import com.example.focusapp.repository.GoalPlanRepository;
 import com.example.focusapp.service.GoalResultService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
-import java.util.List;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/goals")
 public class GoalResultController {
 
-    private final GoalPlanRepository goalPlanRepository;
     private final GoalResultService goalResultService;
 
-    /**
-     * 결과 조회 API
-     *
-     * ✔ 결과가 없으면 Lazy 생성
-     */
-    @GetMapping("/{goalPlanId}/result")
-    public GoalResultResponse getResult(@PathVariable Long goalPlanId) {
-
-        GoalPlan goalPlan = goalPlanRepository.findById(goalPlanId)
-                .orElseThrow(() -> new NotFoundException("GoalPlan 없음"));
-
-        // ⭐ Lazy 생성 (스케줄러 실패 대비)
-        goalResultService.createResult(goalPlan);
-
-        return goalResultService.getResult(goalPlan);
+    // ⭐ 하나씩 가져오기 (추천)
+    @GetMapping("/result/next")
+    public GoalResultResponse getNext(@RequestParam Long userId) {
+        return goalResultService.getNextPendingResult(userId);
     }
 
+    // ⭐ 리스트 조회 (옵션)
     @GetMapping("/result/pending")
-    public List<GoalResultResponse> getPendingResults(@RequestParam Long userId) {
+    public List<GoalResultResponse> getPending(@RequestParam Long userId) {
         return goalResultService.getPendingResults(userId);
     }
 
+    // ⭐ 확인 처리
     @PatchMapping("/{goalPlanId}/result/seen")
     public void markAsSeen(
             @PathVariable Long goalPlanId,
             @RequestParam Long userId
-            // @AuthenticationPrincipal User user // Security 사용 하면 써야함.
     ) {
         goalResultService.markAsSeen(goalPlanId, userId);
-    }
-
-    @PostMapping("/test/result/{goalPlanId}")
-    public GoalResultResponse forceCreateResult(@PathVariable Long goalPlanId) {
-
-        GoalPlan plan = goalPlanRepository.findById(goalPlanId)
-                .orElseThrow(() -> new RuntimeException("GoalPlan 없음"));
-
-        goalResultService.createResult(plan);
-
-        return goalResultService.getResult(plan); // ⭐ 바로 반환
     }
 }

--- a/backend/src/main/java/com/example/focusapp/controller/StatsController.java
+++ b/backend/src/main/java/com/example/focusapp/controller/StatsController.java
@@ -12,8 +12,10 @@ public class StatsController {
 
     private final StatsService statsService;
 
-    @GetMapping("/{userId}")
-    public StatsResponse getStats(@PathVariable Long userId) {
-        return statsService.getStats(userId);
+    @GetMapping
+    public StatsResponse getStats(
+            @RequestParam Long goalPlanId
+    ) {
+        return statsService.getStatsByGoalPlan(goalPlanId);
     }
 }

--- a/backend/src/main/java/com/example/focusapp/repository/GoalPlanRepository.java
+++ b/backend/src/main/java/com/example/focusapp/repository/GoalPlanRepository.java
@@ -19,4 +19,8 @@ public interface GoalPlanRepository extends JpaRepository<GoalPlan, Long> {
     Optional<GoalPlan> findActiveByUserId(Long userId);
     List<GoalPlan> findByEndDate(LocalDate endDate);
     List<GoalPlan> findByUserIdAndStatus(Long userId, GoalStatus status);
+    Optional<GoalPlan> findTopByUserIdAndStatusOrderByCreatedAtDesc(
+            Long userId,
+            GoalStatus status
+    );
 }

--- a/backend/src/main/java/com/example/focusapp/repository/GoalResultRepository.java
+++ b/backend/src/main/java/com/example/focusapp/repository/GoalResultRepository.java
@@ -3,25 +3,14 @@ package com.example.focusapp.repository;
 import com.example.focusapp.entity.GoalPlan;
 import com.example.focusapp.entity.GoalResult;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
-import java.util.Optional;
 import java.util.List;
+import java.util.Optional;
 
 public interface GoalResultRepository extends JpaRepository<GoalResult, Long> {
 
-    boolean existsByGoalPlan(GoalPlan goalPlan);
-    Optional<GoalResult> findByGoalPlan(GoalPlan goalPlan);
-    List<GoalResult> findByGoalPlan_User_IdAndIsSeenFalseOrderByCreatedAtAsc(Long userId);
+    boolean existsByGoalPlan_Id(Long goalPlanId);
+    Optional<GoalResult> findByGoalPlan_Id(Long goalPlanId);
     Optional<GoalResult> findByGoalPlan_IdAndGoalPlan_User_Id(Long goalPlanId, Long userId);
-
-    @Query("""
-    select r from GoalResult r
-    join fetch r.goalPlan gp
-    join fetch gp.goalDefinition
-    where gp.user.id = :userId
-    order by r.createdAt asc
-    """)
-    List<GoalResult> findPendingResultsWithGoal(@Param("userId") Long userId);
+    List<GoalResult> findByGoalPlan_User_IdAndIsSeenFalseOrderByCreatedAtAsc(Long userId);
 }

--- a/backend/src/main/java/com/example/focusapp/service/CharacterService.java
+++ b/backend/src/main/java/com/example/focusapp/service/CharacterService.java
@@ -6,6 +6,7 @@ import com.example.focusapp.repository.CharacterRepository;
 import com.example.focusapp.entity.CharacterImage;
 import com.example.focusapp.entity.GoalPlan;
 import com.example.focusapp.entity.User;
+import com.example.focusapp.entity.GoalStatus;
 import com.example.focusapp.exception.NotFoundException;
 import com.example.focusapp.repository.CharacterImageRepository;
 import com.example.focusapp.repository.GoalPlanRepository;
@@ -32,7 +33,8 @@ public class CharacterService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new NotFoundException("User 없음"));
 
-        GoalPlan goalPlan = goalPlanRepository.findActiveByUserId(userId)
+        GoalPlan goalPlan = goalPlanRepository
+                .findTopByUserIdAndStatusOrderByCreatedAtDesc(userId, GoalStatus.ACTIVE)
                 .orElseThrow(() -> new NotFoundException("GoalPlan 없음"));
 
         System.out.println("goalPlanId = " + goalPlan.getId());
@@ -46,6 +48,28 @@ public class CharacterService {
         int imageLevel = convertLevelToImageLevel(level);
 
         System.out.println("imageLevel = " + imageLevel);
+
+        CharacterImage image = characterImageRepository
+                .findByCharacterIdAndLevel(characterId, imageLevel)
+                .orElseThrow(() -> new NotFoundException("캐릭터 이미지 없음"));
+
+        return new CharacterResponse(
+                characterId,
+                image.getImageUrl(),
+                level
+        );
+    }
+
+    @Transactional(readOnly = true)
+    public CharacterResponse getCurrentCharacterByGoalPlan(Long goalPlanId) {
+
+        GoalPlan goalPlan = goalPlanRepository.findById(goalPlanId)
+                .orElseThrow(() -> new NotFoundException("GoalPlan 없음"));
+
+        int level = goalPlan.getCurrentLevel();
+        Long characterId = goalPlan.getCharacter().getId();
+
+        int imageLevel = convertLevelToImageLevel(level);
 
         CharacterImage image = characterImageRepository
                 .findByCharacterIdAndLevel(characterId, imageLevel)

--- a/backend/src/main/java/com/example/focusapp/service/GoalResultService.java
+++ b/backend/src/main/java/com/example/focusapp/service/GoalResultService.java
@@ -4,6 +4,7 @@ import com.example.focusapp.dto.CharacterResponse;
 import com.example.focusapp.dto.GoalResultResponse;
 import com.example.focusapp.entity.*;
 import com.example.focusapp.repository.DailyTaskRepository;
+import com.example.focusapp.repository.GoalPlanRepository;
 import com.example.focusapp.repository.GoalResultRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -11,139 +12,114 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Random;
+import java.time.LocalDate;
 
 @Service
 @RequiredArgsConstructor
 public class GoalResultService {
 
     private final GoalResultRepository goalResultRepository;
+    private final GoalPlanRepository goalPlanRepository;
     private final DailyTaskRepository dailyTaskRepository;
     private final CharacterService characterService;
 
-    /**
-     * 결과 생성 (핵심)
-     */
+    private static final Random random = new Random();
+
+    // =========================
+    // CREATE RESULT
+    // =========================
     @Transactional
     public void createResult(GoalPlan goalPlan) {
-
-        // ⭐ immutable 보장
-        if (goalResultRepository.existsByGoalPlan(goalPlan)) {
-            return;
+        // ⭐ 종료일 +1일 이후인지 체크
+        if (LocalDate.now().isBefore(goalPlan.getEndDate().plusDays(1))) {
+            return; // 아직 결과 생성 시점 아님
         }
+        goalResultRepository.findByGoalPlan_Id(goalPlan.getId())
+                .ifPresentOrElse(
+                        r -> {
+                            // 이미 있으면 아무것도 안함
+                            return;
+                        },
+                        () -> {
+                            double progress = calculateProgress(goalPlan);
+                            ResultType type = calculateResult(progress);
+                            String message = generateMessage(type);
 
-        double progress = calculateProgress(goalPlan);
-
-        ResultType resultType = calculateResult(progress);
-
-        String message = generateMessage(resultType);
-
-        GoalResult result = new GoalResult(
-                goalPlan,
-                resultType,
-                message
-        );
-
-        goalResultRepository.save(result);
+                            GoalResult result = new GoalResult(goalPlan, type, message);
+                            goalResultRepository.save(result);
+                        }
+                );
     }
 
-    /**
-     * 결과 조회 (최종 버전)
-     */
+    // =========================
+    // SINGLE RESULT
+    // =========================
     @Transactional(readOnly = true)
     public GoalResultResponse getResult(GoalPlan goalPlan) {
 
-        GoalResult result = goalResultRepository.findByGoalPlan(goalPlan)
+        GoalResult result = goalResultRepository
+                .findByGoalPlan_IdAndGoalPlan_User_Id(
+                        goalPlan.getId(),
+                        goalPlan.getUser().getId()
+                )
                 .orElseThrow(() -> new RuntimeException("결과 없음"));
 
         CharacterResponse character =
                 characterService.getCurrentCharacter(goalPlan.getUser().getId());
 
-        return new GoalResultResponse(
-                result.getGoalPlan().getId(),
-                result.getResultType(),
-                result.getMessage(),
-                result.getCreatedAt(),
-                character.getImageUrl(),
-                character.getLevel(),
-                goalPlan.getGoalDefinition().getTitle()
-        );
+        return toResponse(result, goalPlan, character);
     }
 
-    /**
-     * 진행률 계산
-     */
-    private double calculateProgress(GoalPlan goalPlan) {
-        long total = dailyTaskRepository.countByGoalPlan(goalPlan);
-        long completed = dailyTaskRepository.countByGoalPlanAndCompletedTrue(goalPlan);
+    // =========================
+    // NEXT RESULT (🔥 핵심)
+    // =========================
+    @Transactional
+    public GoalResultResponse getNextPendingResult(Long userId) {
 
-        if (total == 0) return 0;
+        // ⭐ 1. 모든 goalPlan 결과 생성 보장
+        List<GoalPlan> plans = goalPlanRepository.findByUserId(userId);
+        for (GoalPlan plan : plans) {
+            createResult(plan);
+        }
 
-        return (double) completed / total * 100;
+        // ⭐ 2. 안 본 결과 조회
+        List<GoalResult> results =
+                goalResultRepository.findByGoalPlan_User_IdAndIsSeenFalseOrderByCreatedAtAsc(userId);
+
+        if (results.isEmpty()) return null;
+
+        // ⭐ 3. 가장 오래된 것 1개
+        GoalResult result = results.get(0);
+
+        // ⭐ 4. 소비 처리
+        result.markAsSeen();
+
+        CharacterResponse character =
+                characterService.getCurrentCharacter(userId);
+
+        return toResponse(result, result.getGoalPlan(), character);
     }
 
-    /**
-     * 결과 판정
-     */
-    private ResultType calculateResult(double progress) {
-        if (progress >= 100) return ResultType.SUCCESS;
-        if (progress >= 30) return ResultType.PARTIAL;
-        return ResultType.FAILED;
-    }
-
-    /**
-     * 메시지 생성
-     */
-    private static final Random random = new Random();
-
-    private String generateMessage(ResultType resultType) {
-        return switch (resultType) {
-            case SUCCESS -> getRandomMessage(List.of(
-                    "목표 달성! 축하합니다 🎓",
-                    "해냈네요! 정말 대단해요 🎉",
-                    "완벽한 결과! 스스로를 칭찬해 주세요 👏"
-            ));
-            case PARTIAL -> getRandomMessage(List.of(
-                    "꾸준함이 가장 큰 힘입니다 💪",
-                    "조금씩 나아가고 있어요 🌱",
-                    "좋은 흐름이에요, 계속 이어가요 🔥"
-            ));
-            case FAILED -> getRandomMessage(List.of(
-                    "다음엔 더 성장할 수 있어요 🙂",
-                    "실패는 과정일 뿐이에요 🚀",
-                    "이번 경험이 다음 성공의 발판이에요 💡"
-            ));
-        };
-    }
-
-    private String getRandomMessage(List<String> messages) {
-        return messages.get(random.nextInt(messages.size()));
-    }
-
-    // 미확인 결과 목록 조회
+    // =========================
+    // PENDING LIST
+    // =========================
     @Transactional(readOnly = true)
     public List<GoalResultResponse> getPendingResults(Long userId) {
 
         List<GoalResult> results =
-                goalResultRepository.findPendingResultsWithGoal(userId);
+                goalResultRepository.findByGoalPlan_User_IdAndIsSeenFalseOrderByCreatedAtAsc(userId);
 
-        // ⭐ 한 번만 호출
-        CharacterResponse character = characterService.getCurrentCharacter(userId);
+        CharacterResponse character =
+                characterService.getCurrentCharacter(userId);
 
         return results.stream()
-                .map(result -> new GoalResultResponse(
-                        result.getGoalPlan().getId(),
-                        result.getResultType(),
-                        result.getMessage(),
-                        result.getCreatedAt(),
-                        character.getImageUrl(),
-                        character.getLevel(),
-                        result.getGoalPlan()
-                                .getGoalDefinition()
-                                .getTitle()
-                )).toList();
+                .map(r -> toResponse(r, r.getGoalPlan(), character))
+                .toList();
     }
 
-    // 확인 처리
+    // =========================
+    // MARK AS SEEN
+    // =========================
     @Transactional
     public void markAsSeen(Long goalPlanId, Long userId) {
 
@@ -152,5 +128,60 @@ public class GoalResultService {
                 .orElseThrow(() -> new RuntimeException("결과 없음"));
 
         result.markAsSeen();
+    }
+
+    // =========================
+    // UTILS
+    // =========================
+    private GoalResultResponse toResponse(
+            GoalResult result,
+            GoalPlan plan,
+            CharacterResponse character
+    ) {
+        return new GoalResultResponse(
+                plan.getId(),
+                result.getResultType(),
+                result.getMessage(),
+                result.getCreatedAt(),
+                character.getImageUrl(),
+                character.getLevel(),
+                plan.getGoalDefinition().getTitle()
+        );
+    }
+
+    private double calculateProgress(GoalPlan goalPlan) {
+        long total = dailyTaskRepository.countByGoalPlan(goalPlan);
+        long done = dailyTaskRepository.countByGoalPlanAndCompletedTrue(goalPlan);
+        return total == 0 ? 0 : (double) done / total * 100;
+    }
+
+    private ResultType calculateResult(double progress) {
+        if (progress >= 100) return ResultType.SUCCESS;
+        if (progress >= 30) return ResultType.PARTIAL;
+        return ResultType.FAILED;
+    }
+
+    private String generateMessage(ResultType type) {
+        return switch (type) {
+            case SUCCESS -> getRandom(List.of(
+                    "목표 달성! 축하합니다 🎓",
+                    "해냈네요! 정말 대단해요 🎉",
+                    "완벽한 결과! 👏"
+            ));
+            case PARTIAL -> getRandom(List.of(
+                    "조금씩 나아가고 있어요 🌱",
+                    "좋은 흐름이에요 🔥",
+                    "꾸준함이 중요합니다 💪"
+            ));
+            case FAILED -> getRandom(List.of(
+                    "다음엔 더 좋아질 거예요 🙂",
+                    "과정이 중요합니다 🚀",
+                    "이번 경험도 의미 있어요 💡"
+            ));
+        };
+    }
+
+    private String getRandom(List<String> list) {
+        return list.get(random.nextInt(list.size()));
     }
 }

--- a/backend/src/main/java/com/example/focusapp/service/StatsService.java
+++ b/backend/src/main/java/com/example/focusapp/service/StatsService.java
@@ -18,10 +18,10 @@ public class StatsService {
     private final GoalPlanRepository goalPlanRepository;
     private final DailyTaskRepository dailyTaskRepository;
 
-    public StatsResponse getStats(Long userId) {
-        GoalPlan goalPlan = goalPlanRepository
-                .findTopByUserIdOrderByCreatedAtDesc(userId)
-                .orElseThrow(() -> new IllegalArgumentException("목표 없음"));
+    public StatsResponse getStatsByGoalPlan(Long goalPlanId) {
+
+        GoalPlan goalPlan = goalPlanRepository.findById(goalPlanId)
+                .orElseThrow(() -> new NotFoundException("목표 없음"));
 
         long completed = dailyTaskRepository.countByGoalPlanAndCompletedTrue(goalPlan);
         long total = dailyTaskRepository.countByGoalPlan(goalPlan);
@@ -29,7 +29,7 @@ public class StatsService {
         return new StatsResponse(
                 (int) completed,
                 (int) total,
-                0,
+                0, // 🔥 streak 아직 안함
                 goalPlan.getCurrentLevel()
         );
     }

--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -22,7 +22,6 @@ const theme = {
 };
 
 export default function App() {
-    const [results, setResults] = useState<any[]>([]);
     const [current, setCurrent] = useState<any | null>(null);
     const [visible, setVisible] = useState(false);
     const [userId, setUserId] = useState<number | null>(null);
@@ -47,38 +46,27 @@ export default function App() {
     const checkResult = async () => {
         try {
             if (!userId) return;
-            const res = await api.get(`/goals/result/pending?userId=${userId}`);
+
+            const res = await api.get(`/goals/result/next?userId=${userId}`);
             const data = res.data;
 
-            if (!data || data.length === 0) return;
+            if (!data) return;
 
-            setResults(data);
-            setCurrent(data[0]);
+            setCurrent(data);
             setVisible(true);
 
         } catch (e) {
             console.log(e);
         }
     };
+
     const handleClose = async () => {
-        try {
-            if (!current) return;
-            api.patch(`/goals/${current.goalPlanId}/result/seen?userId=${userId}`);
-        } catch (e) {
-            console.log(e);
-        }
+        setVisible(false);
+        setCurrent(null);
 
-        const nextResults = results.slice(1);
-
-        if (nextResults.length === 0) {
-            setVisible(false);
-            setResults([]);
-            setCurrent(null);
-            return;
-        }
-
-        setResults(nextResults);
-        setCurrent(nextResults[0]);
+        setTimeout(() => {
+            checkResult();
+        }, 500);
     };
 
     return (

--- a/frontend/src/api/mock.ts
+++ b/frontend/src/api/mock.ts
@@ -1,18 +1,4 @@
-import { DashboardSummary, GoalCategory, Task } from '../types';
-
-export const mockCategories: GoalCategory[] = [
-  { id: 1, name: 'Water', colorHex: '#d8c2ff', emoji: '🥚' },
-  { id: 2, name: 'Study', colorHex: '#f7d0ef', emoji: '👶' },
-  { id: 3, name: 'Job Change', colorHex: '#d7f7a0', emoji: '🧑‍🎓' }
-];
-
-export const mockTasks: Task[] = [
-  { id: 1, title: '백준 알고리즘 19222번 풀기', categoryId: 2, completed: false },
-  { id: 2, title: '백준 알고리즘 20392번 작성', categoryId: 2, completed: false },
-  { id: 3, title: '리트코드 Medium 2문제 풀기', categoryId: 2, completed: true },
-  { id: 4, title: 'CJ 지원서 제출', categoryId: 3, completed: true },
-  { id: 5, title: '네이버 자소서 3번 문항 수정', categoryId: 3, completed: false }
-];
+import { DashboardSummary } from '../types';
 
 export const mockSummary: DashboardSummary = {
   streak: 49,

--- a/frontend/src/components/CategoryChip.tsx
+++ b/frontend/src/components/CategoryChip.tsx
@@ -1,18 +1,62 @@
 import { StyleSheet, Text, View } from 'react-native';
 import { GoalCategory } from '../types';
+import { TouchableOpacity } from 'react-native';
+import { colors } from '../theme/colors';
 
-export default function CategoryChip({ category }: { category: GoalCategory }) {
+export default function CategoryChip({
+                                       category,
+                                       isSelected,
+                                       onPress
+                                     }: {
+  category: GoalCategory;
+  isSelected: boolean;
+  onPress: () => void;
+}) {
+  const isActive = category.active;
+    const getOpacity = () => {
+        if (isSelected) return 1;
+        if (!category.active) return 0.5;
+        return 0.8;
+    };
   return (
-    <View style={[styles.container, { backgroundColor: category.colorHex }]}> 
-      <Text style={styles.emoji}>{category.emoji}</Text>
-      <Text style={styles.label}>{category.name}</Text>
-    </View>
+      <TouchableOpacity onPress={onPress}>
+          <View
+              style={[
+                  styles.container,
+                  {
+                      backgroundColor: isActive ? '#ffffff' : '#2A2A2A',
+                      opacity: getOpacity(),
+
+                      borderWidth: 2,
+                      borderColor: isSelected ? category.colorHex : 'transparent',
+
+                      transform: [{ scale: isSelected ? 1.02 : 1 }],
+
+                      shadowColor: category.colorHex,
+                      shadowOpacity: isSelected ? 0.2 : 0,
+                      shadowRadius: isSelected ? 6 : 0,
+                      shadowOffset: { width: 0, height: 2 },
+
+                      elevation: isSelected ? 3 : 0,
+                  }
+              ]}
+          >
+          <Text style={styles.emoji}>{category.emoji}</Text>
+          <Text
+              style={[
+                styles.label,
+                { color: isActive ? '#1c1c1c' : '#AAAAAA' }
+              ]}
+          >
+            {category.name}
+          </Text>
+        </View>
+      </TouchableOpacity>
   );
 }
-
 const styles = StyleSheet.create({
   container: {
-    paddingHorizontal: 14,
+    paddingHorizontal: 12,
     paddingVertical: 10,
     borderRadius: 999,
     marginRight: 8,

--- a/frontend/src/components/DailyTaskSection.tsx
+++ b/frontend/src/components/DailyTaskSection.tsx
@@ -8,12 +8,16 @@ import TaskInputModal from '../components/TaskInputModal';
 
 export default function DailyTaskSection({
                                              goalPlanId,
+                                             selectedDate,
+                                             isActive,
                                              onLevelChange,
                                              refreshKey,
                                              onLevelUp,
                                              onTasksUpdated,
                                          }: {
     goalPlanId: number;
+    selectedDate: string;
+    isActive: boolean;
     onLevelChange?: (level: number) => void;
     refreshKey?: number;
     onLevelUp?: () => void;
@@ -27,11 +31,16 @@ export default function DailyTaskSection({
 
     useEffect(() => {
         fetchTask();
-    }, [goalPlanId, refreshKey]);
+    }, [goalPlanId, selectedDate, refreshKey]);
 
     const fetchTask = async () => {
         try {
-            const res = await api.get(`/daily-tasks/active/${goalPlanId}`);
+            const res = await api.get(
+                `/daily-tasks/active/${goalPlanId}`,
+                {
+                    params: { date: selectedDate }
+                }
+            );
 
             const taskList = Array.isArray(res.data)
                 ? res.data
@@ -49,6 +58,7 @@ export default function DailyTaskSection({
 
     const handleSubmit = async (title: string) => {
         try {
+            if (!isActive) return;
             if (editTaskItem) {
                 setTasks((prev) =>
                     prev.map((t) =>
@@ -88,6 +98,7 @@ export default function DailyTaskSection({
     };
 
     const handleDelete = async () => {
+        if (!isActive) return;
         if (!editTaskItem) return;
         const id = editTaskItem.id;
         const prevTasks = tasks;
@@ -113,11 +124,13 @@ export default function DailyTaskSection({
     };
 
     const handleLongPress = (task: Task) => {
+        if (!isActive) return;
         setEditTaskItem(task);
         setModalVisible(true);
     };
 
     const toggleTask = async (id: number) => {
+        if (!isActive) return;
         const prevTasks = tasks;
 
         setTasks((prev) =>
@@ -164,12 +177,21 @@ export default function DailyTaskSection({
     return (
         <>
             <TaskSection
-                title="오늘 목표"
+                title="목표"
                 color="#bbf7d0"
                 tasks={tasks}
-                onToggle={toggleTask}
+                onToggle={isActive ? toggleTask : undefined}
                 onAdd={() => {
-                    setEditTaskItem(null); // ⭐ 추가 모드
+                    if (!isActive) {
+                        Toast.show({
+                            type: 'info',
+                            text1: '종료된 목표는 추가할 수 없어요',
+                            position: 'bottom',
+                        });
+                        return;
+                    }
+
+                    setEditTaskItem(null);
                     setModalVisible(true);
                 }}
                 onLongPress={handleLongPress}

--- a/frontend/src/components/ResultCard.tsx
+++ b/frontend/src/components/ResultCard.tsx
@@ -15,7 +15,6 @@ import { CONFIG } from "../constants/config";
 
 const ResultCard = ({ type, message, level, character, goalTitle, onClose }: any) => {
     const ref = useRef<ViewShot | null>(null);
-
     const [loading, setLoading] = useState(false);
     const [downloading, setDownloading] = useState(false);
     const [imgError, setImgError] = useState(false);
@@ -32,8 +31,9 @@ const ResultCard = ({ type, message, level, character, goalTitle, onClose }: any
 
     // 📸 공통 캡처 함수
     const captureImage = async () => {
-        await new Promise((r) => setTimeout(r, 150));
-        return await ref.current?.capture();
+        await new Promise(r => setTimeout(r, 150));
+        if (!ref.current) return;
+        return ref.current.capture();
     };
 
     // 📤 공유
@@ -240,8 +240,8 @@ const iconButtonStyle = {
     height: 40,
     borderRadius: 20,
     backgroundColor: "rgba(0,0,0,0.5)",
-    justifyContent: "center",
-    alignItems: "center"
+    justifyContent: "center" as const,
+    alignItems: "center" as const,
 };
 
 export default ResultCard;

--- a/frontend/src/components/TaskSection.tsx
+++ b/frontend/src/components/TaskSection.tsx
@@ -33,7 +33,7 @@ export default function TaskSection({
         </View>
 
         {tasks.length === 0 ? (
-            <Text style={styles.emptyText}>오늘 할 일이 없습니다</Text>
+            <Text style={styles.emptyText}>할 일이 없습니다</Text>
         ) : (
             tasks.map((task) => (
                 <Pressable

--- a/frontend/src/screens/CategoryCreateScreen.tsx
+++ b/frontend/src/screens/CategoryCreateScreen.tsx
@@ -351,7 +351,7 @@ const styles = StyleSheet.create({
     },
     content: {
         paddingHorizontal: 20,
-        paddingTop: 16,
+        paddingTop: 40,
         paddingBottom: 40,
     },
     headerRow: {

--- a/frontend/src/screens/HomeScreen.tsx
+++ b/frontend/src/screens/HomeScreen.tsx
@@ -18,116 +18,136 @@ import MonthlyCalendar from '../components/MonthlyCalendar';
 import PixelCard from '../components/PixelCard';
 import DailyTaskSection from '../components/DailyTaskSection';
 
-import { mockCategories, mockSummary } from '../api/mock';
+import { mockSummary } from '../api/mock';
 import { colors } from '../theme/colors';
 import { STORAGE_KEYS } from '../constants/storage';
 
 import type { BottomTabScreenProps } from '@react-navigation/bottom-tabs';
 import { MainTabParamList } from '../types/navigation';
 import { api } from '../api/client';
-
+import { GoalCategory } from "../types";
 
 type Props = BottomTabScreenProps<MainTabParamList, 'Home'>;
 
-export default function HomeScreen({ navigation,route }: Props) {
+export default function HomeScreen({ navigation }: Props) {
     const [username, setUsername] = useState('');
     const [currentLevel, setCurrentLevel] = useState<number | null>(null);
     const [goalPlanId, setGoalPlanId] = useState<number | null>(null);
+
     const [refreshing, setRefreshing] = useState(false);
     const [refreshKey, setRefreshKey] = useState(0);
-    const [characterImageUrl, setCharacterImageUrl] = useState<string | undefined>();
+    const [characterImageUrl, setCharacterImageUrl] = useState<string>();
 
     const [completedDates, setCompletedDates] = useState<string[]>([]);
     const [preferredEmoji, setPreferredEmoji] = useState('🌱');
 
-    const [motto, setMotto] = useState('');
+    const [categories, setCategories] = useState<GoalCategory[]>([]);
+    const [selectedGoalId, setSelectedGoalId] = useState<number | null>(null);
 
     const today = new Date();
-
     const [year, setYear] = useState(today.getFullYear());
     const [month, setMonth] = useState(today.getMonth() + 1);
 
-    //사용자가 누른 날짜 강조 표시
     const [selectedDate, setSelectedDate] = useState(
         `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, '0')}-${String(today.getDate()).padStart(2, '0')}`
     );
-
+    const selectedCategory = categories.find(c => c.id === selectedGoalId);
     const [menuVisible, setMenuVisible] = useState(false);
 
-    const loadData = async () => {
+    // ✅ 최초 데이터 (카테고리 + 유저)
+    const loadInitial = async () => {
         try {
             const savedUsername = await AsyncStorage.getItem(STORAGE_KEYS.USERNAME);
-            const savedGoalPlanId = await AsyncStorage.getItem(STORAGE_KEYS.GOAL_PLAN_ID);
             const savedUserId = await AsyncStorage.getItem(STORAGE_KEYS.USER_ID);
 
             if (savedUsername) setUsername(savedUsername);
-            if (savedGoalPlanId) {
-                const goalId = Number(savedGoalPlanId);
+            if (!savedUserId) return;
 
-                setGoalPlanId(goalId);
+            const uid = Number(savedUserId);
 
-                const res = await api.get(`/goals/${goalId}`);
+            const goalRes = await api.get(`/goals/users/${uid}`);
 
-                setMotto(res.data.motto ?? '');
+            const getPastelColor = () => {
+                const h = Math.floor(Math.random() * 360);
+                const s = 55;
+                const l = 80;
+                return `hsl(${h}, ${s}%, ${l}%)`;
+            };
+
+            const mapped = goalRes.data
+                .sort((a: any, b: any) => b.id - a.id)
+                .map((goal: any) => ({
+                    id: goal.id,
+                    name: goal.title,
+                    emoji: goal.emoji,
+                    active: goal.active,
+                    motto: goal.motto,
+                    colorHex: getPastelColor(),
+                }));
+
+            setCategories(mapped);
+
+            if (!goalPlanId) {
+                const first = mapped[0];
+                if (first) {
+                    setSelectedGoalId(first.id);
+                    setGoalPlanId(first.id);
+                }
             }
 
-            if (savedUserId) {
-                const uid = Number(savedUserId);
-                await fetchCharacter(uid);
-            }
         } catch (e) {
-            console.log('loadData error:', e);
+            console.log(e);
         }
     };
 
     useFocusEffect(
         useCallback(() => {
-            loadData();
+            loadInitial();
         }, [])
     );
 
+    // ✅ goalPlanId 바뀔 때만 필요한 데이터 fetch
     useEffect(() => {
-        const fetchCalendar = async () => {
-            try {
-                if (!goalPlanId) return;
+        if (!goalPlanId) return;
 
-                const res = await api.get(`/goal-plans/${goalPlanId}/calendar`, {
-                    params: {
-                        year,
-                        month,
-                    },
-                });
-
-                setCompletedDates(res.data.completedDates ?? []);
-                setPreferredEmoji(res.data.preferredEmoji ?? '🌱');
-
-            } catch (e) {
-                console.log('달력 조회 실패:', e);
-                setCompletedDates([]);
-                setPreferredEmoji('🌱');
-            }
-        };
-
+        fetchCharacter();
         fetchCalendar();
+
     }, [goalPlanId, year, month, refreshKey]);
 
-    const onRefresh = async () => {
-        setRefreshing(true);
-        await loadData();
-        setRefreshKey((prev) => prev + 1);
-        setRefreshing(false);
-    };
-
-    const fetchCharacter = async (uid: number) => {
+    const fetchCharacter = async () => {
         try {
-            if (!uid) return;
-
-            const res = await api.get(`/characters/current?userId=${uid}`);
+            const res = await api.get(`/characters/current?goalPlanId=${goalPlanId}`);
             setCharacterImageUrl(res.data.imageUrl);
             setCurrentLevel(res.data.level);
         } catch (e) {
             console.log(e);
         }
+    };
+
+    const fetchCalendar = async () => {
+        try {
+            const res = await api.get(`/goal-plans/${goalPlanId}/calendar`, {
+                params: { year, month },
+            });
+
+            setCompletedDates(res.data.completedDates ?? []);
+            setPreferredEmoji(res.data.preferredEmoji ?? '🌱');
+        } catch (e) {
+            console.log(e);
+        }
+    };
+
+    const handleSelectCategory = (goalId: number) => {
+        setSelectedGoalId(goalId);
+        setGoalPlanId(goalId);
+    };
+
+    const onRefresh = async () => {
+        setRefreshing(true);
+        await loadInitial();
+        setRefreshKey(prev => prev + 1);
+        setRefreshing(false);
     };
 
     const goPrevMonth = () => {
@@ -156,6 +176,7 @@ export default function HomeScreen({ navigation,route }: Props) {
         setMonth(now.getMonth() + 1);
         setSelectedDate(todayKey);
     };
+
     const handleCategoryCreate = () => {
         setMenuVisible(false);
         navigation.navigate('CategoryCreate');
@@ -172,6 +193,7 @@ export default function HomeScreen({ navigation,route }: Props) {
         console.log('리마인더 관리');
         // navigation.navigate('ReminderManage');
     };
+
     return (
         <>
             <ScrollView
@@ -184,8 +206,9 @@ export default function HomeScreen({ navigation,route }: Props) {
                 <View style={styles.headerRow}>
                     <View style={styles.headerTextBox}>
                         <Text style={styles.title}>
-                            {username ? `${username}님, ${motto || '오늘도 한 칸 전진'}`
-                                : motto || '오늘도 한 칸 전진'}
+                            {username
+                                ? `${username}님, ${selectedCategory?.motto || '오늘도 한 칸 전진'}`
+                                : selectedCategory?.motto || '오늘도 한 칸 전진'}
                         </Text>
                         <Text style={styles.subtitle}>
                             {mockSummary.streak}일째 루틴 이어가는 중
@@ -200,13 +223,14 @@ export default function HomeScreen({ navigation,route }: Props) {
                     </TouchableOpacity>
                 </View>
 
-                <ScrollView
-                    horizontal
-                    showsHorizontalScrollIndicator={false}
-                    style={styles.chipRow}
-                >
-                    {mockCategories.map((category) => (
-                        <CategoryChip key={category.id} category={category} />
+                <ScrollView horizontal showsHorizontalScrollIndicator={false} style={styles.chipRow}>
+                    {categories.map((category) => (
+                        <CategoryChip
+                            key={category.id}
+                            category={category}
+                            isSelected={category.id === selectedGoalId}
+                            onPress={() => handleSelectCategory(category.id)}
+                        />
                     ))}
                 </ScrollView>
 
@@ -230,10 +254,12 @@ export default function HomeScreen({ navigation,route }: Props) {
                 {goalPlanId && (
                     <DailyTaskSection
                         goalPlanId={goalPlanId}
+                        selectedDate={selectedDate}
                         onLevelChange={setCurrentLevel}
                         refreshKey={refreshKey}
                         onLevelUp={fetchCharacter}
-                        onTasksUpdated={() => setRefreshKey((prev) => prev + 1)}
+                        isActive={selectedCategory?.active ?? false}
+                        onTasksUpdated={() => setRefreshKey(prev => prev + 1)}
                     />
                 )}
             </ScrollView>
@@ -276,66 +302,13 @@ export default function HomeScreen({ navigation,route }: Props) {
 }
 
 const styles = StyleSheet.create({
-    container: {
-        flex: 1,
-        backgroundColor: colors.background,
-    },
-    content: {
-        paddingHorizontal: 20,
-        paddingTop: 64,
-        paddingBottom: 120,
-    },
-    headerRow: {
-        flexDirection: 'row',
-        justifyContent: 'space-between',
-        alignItems: 'flex-start',
-    },
-    headerTextBox: {
-        flex: 1,
-        paddingRight: 12,
-    },
-    title: {
-        color: colors.text,
-        fontSize: 28,
-        fontWeight: '900',
-    },
-    subtitle: {
-        color: colors.muted,
-        marginTop: 6,
-        fontSize: 15,
-    },
-    chipRow: {
-        marginTop: 18,
-    },
-    level: {
-        color: colors.text,
-        fontSize: 18,
-        fontWeight: '700',
-        marginTop: 14,
-        marginBottom: 12,
-    },
-    calendarHeaderRow: {
-        marginTop: 16,
-        marginBottom: 8,
-        flexDirection: 'row',
-        justifyContent: 'space-between',
-        alignItems: 'center',
-    },
-    monthButton: {
-        width: 40,
-        height: 40,
-        borderRadius: 12,
-        backgroundColor: '#FFFFFF',
-        justifyContent: 'center',
-        alignItems: 'center',
-    },
-    dropdownOverlay: {
-        flex: 1,
-        backgroundColor: 'rgba(0,0,0,0.35)',
-    },
-    modalBackdrop: {
-        flex: 1,
-    },
+    container: { flex: 1, backgroundColor: colors.background },
+    content: { paddingHorizontal: 20, paddingTop: 64, paddingBottom: 120 },
+    headerRow: { flexDirection: 'row', justifyContent: 'space-between' },
+    headerTextBox: { flex: 1 },
+    title: { color: colors.text, fontSize: 28, fontWeight: '900' },
+    subtitle: { color: colors.muted, marginTop: 6 },
+    chipRow: { marginTop: 18, paddingLeft: 5,},
     menuButton: {
         width: 42,
         height: 42,
@@ -343,8 +316,8 @@ const styles = StyleSheet.create({
         backgroundColor: '#1E1E22',
         justifyContent: 'center',
         alignItems: 'center',
-        marginTop: 2,
     },
+    dropdownOverlay: { flex: 1, backgroundColor: 'rgba(0,0,0,0.35)' },
     dropdownWrapper: {
         position: 'absolute',
         top: 105,

--- a/frontend/src/screens/InitScreen.tsx
+++ b/frontend/src/screens/InitScreen.tsx
@@ -4,10 +4,10 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { RootStackParamList } from '../types/navigation';
 import { STORAGE_KEYS } from '../constants/storage';
-
+import { CONFIG } from '../constants/config';
 type Props = NativeStackScreenProps<RootStackParamList, 'Init'>;
 
-const BASE_URL = 'http://172.20.1.227:8080/api';
+const BASE_URL = CONFIG.BASE_URL;
 
 type StatusResponse = {
     userId: number;

--- a/frontend/src/screens/StatsScreen.tsx
+++ b/frontend/src/screens/StatsScreen.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import {
   ScrollView,
   RefreshControl,
@@ -14,8 +14,8 @@ import { api } from '../api/client';
 import { colors } from '../theme/colors';
 import { STORAGE_KEYS } from '../constants/storage';
 import { CONFIG } from '../constants/config';
-import {mockCategories} from "../api/mock";
 import CategoryChip from "../components/CategoryChip";
+import { GoalCategory } from "../types";
 
 export default function StatsScreen() {
   const [stats, setStats] = useState({
@@ -27,45 +27,105 @@ export default function StatsScreen() {
 
   const [refreshing, setRefreshing] = useState(false);
   const [characterImageUrl, setCharacterImageUrl] = useState<string | null>(null);
+  const [categories, setCategories] = useState<GoalCategory[]>([]);
+  const [selectedGoalId, setSelectedGoalId] = useState<number | null>(null);
+  const [goalPlanId, setGoalPlanId] = useState<number | null>(null);
 
   useFocusEffect(
       useCallback(() => {
-        fetchAll();
+        void loadCategories();
       }, [])
   );
 
-  const fetchAll = async () => {
-    await Promise.all([fetchStats(), fetchCharacter()]);
-  };
+  useEffect(() => {
+    if (goalPlanId) {
+      void fetchCharacter();
+      void fetchStats();
+    }
+  }, [goalPlanId]);
 
   const fetchStats = async () => {
+    try {
+      if (!goalPlanId) return;
+
+      const res = await api.get('/stats', {
+        params: { goalPlanId }
+      });
+
+      setStats(res.data);
+    } catch (err) {
+      console.log(err);
+    }
+  };
+
+  const loadCategories = async () => {
     try {
       const userId = await AsyncStorage.getItem(STORAGE_KEYS.USER_ID);
       if (!userId) return;
 
-      const res = await api.get(`/stats/${userId}`);
-      setStats(res.data);
-    } catch (err) {
+      const goalRes = await api.get(`/goals/users/${userId}`);
+
+      const getPastelColor = () => {
+        const h = Math.floor(Math.random() * 360);
+        const s = 55;
+        const l = 80;
+        return `hsl(${h}, ${s}%, ${l}%)`;
+      };
+
+      const mapped: GoalCategory[] = goalRes.data
+          .sort((a: any, b: any) => b.id - a.id)
+          .map((goal: any) => ({
+            id: goal.id,
+            name: goal.title,
+            emoji: goal.emoji,
+            active: goal.active,
+            motto: goal.motto,
+            colorHex: getPastelColor(),
+          }));
+
+      setCategories(mapped);
+
+      // 👉 최초 1번만 설정
+      if (mapped.length > 0) {
+        const active = mapped.find(c => c.active) || mapped[0];
+
+        setSelectedGoalId(active.id);
+        setGoalPlanId(active.id);
+      }
+
+    } catch (e) {
+      console.log(e);
     }
   };
 
   const fetchCharacter = async () => {
     try {
-      const userId = await AsyncStorage.getItem(STORAGE_KEYS.USER_ID);
-      if (!userId) return;
+      if (!goalPlanId) return;
 
-      const res = await api.get(`/characters/current?userId=${userId}`);
+      const res = await api.get(`/characters/current?goalPlanId=${goalPlanId}`);
       const path = res.data.imageUrl;
-      const fullUrl = path?.startsWith('http') ? path : `${CONFIG.IMAGE_BASE_URL}${path}`;
+      const fullUrl = path?.startsWith('http')
+          ? path
+          : `${CONFIG.IMAGE_BASE_URL}${path}`;
 
       setCharacterImageUrl(fullUrl);
     } catch (err) {
+      console.log(err);
+    }
+  };
+
+  const handleSelectCategory = async (goalId: number) => {
+    try {
+      setSelectedGoalId(goalId);
+      setGoalPlanId(goalId);
+    } catch (e) {
+      console.log(e);
     }
   };
 
   const onRefresh = async () => {
     setRefreshing(true);
-    await fetchAll();
+    await fetchStats();
     setRefreshing(false);
   };
 
@@ -83,11 +143,18 @@ export default function StatsScreen() {
           }
       >
         <Text style={styles.title}>Stats</Text>
+
         <ScrollView horizontal showsHorizontalScrollIndicator={false} style={styles.chipRow}>
-          {mockCategories.map((category) => (
-              <CategoryChip key={category.id} category={category} />
+          {categories.map((category) => (
+              <CategoryChip
+                  key={category.id}
+                  category={category}
+                  isSelected={category.id === selectedGoalId}
+                  onPress={() => handleSelectCategory(category.id)}
+              />
           ))}
         </ScrollView>
+
         <View style={styles.card}>
           <Text style={styles.label}>현재 캐릭터</Text>
           <Text style={styles.value}>Lv.{stats.currentLevel}</Text>
@@ -99,6 +166,7 @@ export default function StatsScreen() {
               />
           )}
         </View>
+
         <View style={styles.card}>
           <Text style={styles.label}>완료율</Text>
           <Text style={styles.value}>{rate}%</Text>
@@ -151,10 +219,9 @@ const styles = StyleSheet.create({
   character: {
     width: 100,
     height: 100,
-    marginTop: 0,
     alignSelf: 'center',
   },
   chipRow: {
-    marginBottom: 15,
+    marginBottom: 15, paddingLeft: 5
   },
 });

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1,8 +1,10 @@
 export type GoalCategory = {
   id: number;
   name: string;
-  colorHex: string;
   emoji: string;
+  colorHex: string;
+  active: boolean;
+  motto?: string;
 };
 
 export type Task = {
@@ -12,6 +14,7 @@ export type Task = {
   currentLevel: number;
   message?: string;
   messageType?: string;
+  selectedDate: string;
 };
 
 export type DashboardSummary = {

--- a/frontend/src/types/navigation.ts
+++ b/frontend/src/types/navigation.ts
@@ -11,4 +11,5 @@ export type MainTabParamList = {
     Home: { userId: number };
     Stats: { userId: number };
     Settings: { userId: number };
+    CategoryCreate: undefined;
 };


### PR DESCRIPTION
### 🚀 작업 요약

카테고리(= 목표)를 기준으로 사용자 데이터를 조회하도록 구조를 개편하고,
선택된 카테고리에 따라 Home 및 Stats 화면의 데이터가 동적으로 갱신되도록 수정

또한 캘린더 날짜 선택 시 해당 날짜의 목표를 조회하고,
완료된 목표의 결과를 개별적으로 확인할 수 있도록 로직 개선

---

### 🛠️ 주요 변경 사항

#### 1. Frontend (React Native)

* [x] 사용자 카테고리 목록 조회 및 선택 기능 추가
* [x] HomeScreen

  * 선택된 카테고리에 따라 캐릭터 / 캘린더 / 목표 데이터 조회
* [x] StatsScreen

  * 사용자 카테고리 조회
  * 선택된 카테고리 기준 진행 상황 표시
* [x] 캘린더 날짜 클릭 시 해당 날짜 목표 조회 기능 추가
* [x] 완료된 목표 결과 화면

  * 여러 개일 경우 개별적으로 확인 가능하도록 개선
* [x] Category / Task / Result 관련 컴포넌트 데이터 흐름 수정

---

#### 2. Backend (Spring Boot)

* [x] 사용자 기준 카테고리(목표) 조회 API 연동
* [x] 카테고리 선택 시 관련 데이터 조회 로직 수정

  * Character
  * DailyTask
  * GoalResult
  * Stats
* [x] 날짜 기준 목표 조회 기능 개선
* [x] 목표 완료 결과 조회 로직 개선 (단건 조회 구조로 변경)

---

#### 3. API / Domain 개선

* [x] “카테고리 = 목표” 기준으로 데이터 흐름 통일
* [x] 카테고리 선택 → 관련 데이터 조회 구조 확립
* [x] 날짜 기반 목표 조회 API 흐름 정리
* [x] GoalResult 조회 방식 개선 (리스트 → 개별 조회)

---

### 🧪 테스트 및 검증 결과

* [x] 사용자 카테고리 목록 정상 조회 확인
* [x] 카테고리 선택 시 Home 데이터 정상 변경 확인
* [x] Stats 화면에서 카테고리별 진행 상황 정상 표시 확인
* [x] 캘린더 날짜 클릭 시 목표 조회 정상 동작 확인
* [x] 완료된 목표 결과 개별 조회 정상 동작 확인
* [x] 전체 데이터 흐름 (FE ↔ BE) 정상 연동 확인

---

### 📌 참고

* 카테고리를 기준으로 데이터 흐름을 통합하여 구조 단순화
* 향후 다중 목표/통계 확장에 유리한 구조로 개선