### PR TITLE
feat: 루틴 관리 기능 구현 및 DailyTask 연동 처리 (조회/삭제/soft delete)

### DIFF
--- a/backend/src/main/java/com/example/focusapp/controller/DailyTaskController.java
+++ b/backend/src/main/java/com/example/focusapp/controller/DailyTaskController.java
@@ -41,12 +41,14 @@ public class DailyTaskController {
                 .map(task -> new DailyTaskResponse(
                         task.getId(),
                         goalPlan.getId(),
+                        task.getRoutine() != null ? task.getRoutine().getId() : null,
                         task.getTitle(),
                         task.isCompleted(),
                         goalPlan.getCurrentLevel()
                 ))
                 .toList();
     }
+
     @PatchMapping("/{id}/toggle")
     public ResponseEntity<DailyTaskResponse> toggle(@PathVariable Long id) {
         return ResponseEntity.ok(dailyTaskService.toggle(id));

--- a/backend/src/main/java/com/example/focusapp/controller/RoutineController.java
+++ b/backend/src/main/java/com/example/focusapp/controller/RoutineController.java
@@ -1,0 +1,46 @@
+package com.example.focusapp.controller;
+
+import com.example.focusapp.dto.CreateRoutineRequest;
+import com.example.focusapp.dto.RoutineResponse;
+import com.example.focusapp.entity.Routine;
+import com.example.focusapp.service.RoutineService;
+import com.example.focusapp.exception.NotFoundException;
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/routines")
+public class RoutineController {
+
+    private final RoutineService routineService;
+
+    @PostMapping
+    public ResponseEntity<Void> create(@RequestBody CreateRoutineRequest req) {
+        routineService.createRoutine(req);
+        return ResponseEntity.ok().build();
+    }
+
+    @GetMapping
+    public ResponseEntity<List<RoutineResponse>> getRoutines(
+            @RequestParam Long goalPlanId
+    ) {
+        return ResponseEntity.ok(
+                routineService.getRoutinesByGoal(goalPlanId)
+                        .stream()
+                        .map(RoutineResponse::from)
+                        .toList()
+        );
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> delete(@PathVariable Long id) {
+        routineService.deleteRoutine(id);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/backend/src/main/java/com/example/focusapp/dto/CreateDailyTaskRequest.java
+++ b/backend/src/main/java/com/example/focusapp/dto/CreateDailyTaskRequest.java
@@ -2,10 +2,13 @@ package com.example.focusapp.dto;
 
 import lombok.Getter;
 import lombok.Setter;
+import java.time.LocalDate;
 
 @Getter
 @Setter
 public class CreateDailyTaskRequest {
     private Long goalPlanId;
+    private Long routineId;
     private String title;
+    private LocalDate targetDate;
 }

--- a/backend/src/main/java/com/example/focusapp/dto/CreateRoutineRequest.java
+++ b/backend/src/main/java/com/example/focusapp/dto/CreateRoutineRequest.java
@@ -1,0 +1,18 @@
+package com.example.focusapp.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+@Getter
+@Setter
+public class CreateRoutineRequest {
+    private Long goalPlanId;
+    private String title;
+    private LocalDate startDate;
+    private LocalDate endDate;
+    private Integer interval;
+    private LocalTime time;
+}

--- a/backend/src/main/java/com/example/focusapp/dto/DailyTaskResponse.java
+++ b/backend/src/main/java/com/example/focusapp/dto/DailyTaskResponse.java
@@ -1,28 +1,50 @@
 package com.example.focusapp.dto;
 
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
-@AllArgsConstructor
 public class DailyTaskResponse {
 
     private Long id;
     private Long goalPlanId;
+    private Long routineId;
     private String title;
     private boolean completed;
     private Integer currentLevel;
     private String message;
     private MessageType messageType;
 
-    public DailyTaskResponse(Long id, Long goalPlanId, String title,
-                             boolean completed, Integer currentLevel) {
+    public DailyTaskResponse(Long id,
+                             Long goalPlanId,
+                             Long routineId,
+                             String title,
+                             boolean completed,
+                             Integer currentLevel) {
         this.id = id;
         this.goalPlanId = goalPlanId;
+        this.routineId = routineId;
         this.title = title;
         this.completed = completed;
         this.currentLevel = currentLevel;
         this.message = null;
         this.messageType = null;
+    }
+
+    public DailyTaskResponse(Long id,
+                             Long goalPlanId,
+                             Long routineId,
+                             String title,
+                             boolean completed,
+                             Integer currentLevel,
+                             String message,
+                             MessageType messageType) {
+        this.id = id;
+        this.goalPlanId = goalPlanId;
+        this.routineId = routineId;
+        this.title = title;
+        this.completed = completed;
+        this.currentLevel = currentLevel;
+        this.message = message;
+        this.messageType = messageType;
     }
 }

--- a/backend/src/main/java/com/example/focusapp/dto/RoutineResponse.java
+++ b/backend/src/main/java/com/example/focusapp/dto/RoutineResponse.java
@@ -1,0 +1,12 @@
+package com.example.focusapp.dto;
+
+import com.example.focusapp.entity.Routine;
+
+public record RoutineResponse(
+        Long id,
+        String title
+) {
+    public static RoutineResponse from(Routine r) {
+        return new RoutineResponse(r.getId(), r.getTitle());
+    }
+}

--- a/backend/src/main/java/com/example/focusapp/entity/Routine.java
+++ b/backend/src/main/java/com/example/focusapp/entity/Routine.java
@@ -8,53 +8,54 @@ import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.Where;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
-
+import com.example.focusapp.entity.Routine;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 
 @Entity
-@Table(name = "daily_tasks")
-@SQLDelete(sql = "UPDATE daily_tasks SET deleted_at = now() WHERE id = ?")
+@Table(name = "routines")
+@SQLDelete(sql = "UPDATE routines SET deleted_at = now() WHERE id = ?")
 @Where(clause = "deleted_at IS NULL")
 @Getter
 @Setter
 @NoArgsConstructor
-public class DailyTask {
+public class Routine {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "goal_plan_id", nullable = false)
     private GoalPlan goalPlan;
-
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "routine_id")
-    private Routine routine;
-
-    @Column(nullable = false)
-    private LocalDate targetDate;
 
     @Column(nullable = false)
     private String title;
 
+    @Column(name = "start_date", nullable = false)
+    private LocalDate startDate;
+
+    @Column(name = "end_date", nullable = false)
+    private LocalDate endDate;
+
+    @Column(name = "`interval`")
+    private Integer interval;
+
+    @Column(name = "time")
+    private LocalTime time;
+
     @Column(nullable = false)
-    private boolean completed = false;
-
-    private LocalDateTime completedAt;
-
-    @CreationTimestamp
-    private LocalDateTime createdAt;
-
-    @UpdateTimestamp
-    private LocalDateTime updatedAt;
+    private boolean active = true;
 
     @Column(name = "deleted_at")
     private LocalDateTime deletedAt;
 
-    public DailyTask(GoalPlan goalPlan, LocalDate targetDate) {
-        this.goalPlan = goalPlan;
-        this.targetDate = targetDate;
-    }
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
 }

--- a/backend/src/main/java/com/example/focusapp/exception/BadRequestException.java
+++ b/backend/src/main/java/com/example/focusapp/exception/BadRequestException.java
@@ -1,0 +1,11 @@
+package com.example.focusapp.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.BAD_REQUEST)
+public class BadRequestException extends RuntimeException {
+    public BadRequestException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/example/focusapp/repository/DailyTaskRepository.java
+++ b/backend/src/main/java/com/example/focusapp/repository/DailyTaskRepository.java
@@ -2,6 +2,7 @@ package com.example.focusapp.repository;
 
 import com.example.focusapp.entity.DailyTask;
 import com.example.focusapp.entity.GoalPlan;
+import com.example.focusapp.entity.Routine;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.time.LocalDate;
@@ -12,30 +13,47 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 public interface DailyTaskRepository extends JpaRepository<DailyTask, Long> {
+
+    boolean existsByRoutineAndTargetDate(Routine routine, LocalDate targetDate);
     boolean existsByGoalPlanAndTargetDate(GoalPlan goalPlan, LocalDate targetDate);
-    boolean existsByGoalPlanIdAndTargetDate(Long goalPlanId, LocalDate targetDate);
+
     long countByGoalPlan(GoalPlan goalPlan);
     long countByGoalPlanAndCompletedTrue(GoalPlan goalPlan);
 
     List<DailyTask> findByGoalPlanOrderByTargetDateDesc(GoalPlan goalPlan);
     List<DailyTask> findByGoalPlanAndTargetDate(GoalPlan goalPlan, LocalDate date);
+    List<DailyTask> findByRoutineAndTargetDate(Routine routine, LocalDate date);
+    List<DailyTask> findByRoutineIdAndDeletedAtIsNull(Long routineId);
 
-    Optional<DailyTask> findFirstByGoalPlanAndTargetDateLessThanEqualOrderByTargetDateDesc(
-            GoalPlan goalPlan,
-            LocalDate today
+    @Query("""
+    SELECT COUNT(dt) > 0
+    FROM DailyTask dt
+    WHERE dt.goalPlan = :goalPlan
+    AND dt.targetDate = :date
+    AND dt.routine IS NULL
+    """)
+    boolean existsGoalTaskOnly(
+            @Param("goalPlan") GoalPlan goalPlan,
+            @Param("date") LocalDate date
     );
 
     Optional<DailyTask> findTopByGoalPlanAndTargetDateLessThanEqualOrderByTargetDateDesc(
             GoalPlan goalPlan,
             LocalDate date
     );
+
+    Optional<DailyTask> findTopByRoutineAndTargetDateLessThanEqualOrderByTargetDateDesc(
+            Routine routine,
+            LocalDate date
+    );
+
     @Query(value = """
         SELECT dt.target_date
           FROM daily_tasks dt
-         WHERE dt.goal_plan_id  = :goalPlanId
-         AND dt.target_date >= :startDate
-         AND dt.target_date < :endDate
-         GROUP BY dt.goal_plan_id,target_date
+         WHERE dt.goal_plan_id = :goalPlanId
+           AND dt.target_date >= :startDate
+           AND dt.target_date < :endDate
+         GROUP BY dt.goal_plan_id, dt.target_date
         HAVING COUNT(*) = SUM(CASE WHEN dt.completed = 1 THEN 1 ELSE 0 END)
          ORDER BY dt.target_date
         """, nativeQuery = true)

--- a/backend/src/main/java/com/example/focusapp/repository/RoutineRepository.java
+++ b/backend/src/main/java/com/example/focusapp/repository/RoutineRepository.java
@@ -1,0 +1,10 @@
+package com.example.focusapp.repository;
+
+import com.example.focusapp.entity.Routine;
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.List;
+
+public interface RoutineRepository extends JpaRepository<Routine, Long> {
+    List<Routine> findByGoalPlanId(Long goalPlanId);
+    List<Routine> findByGoalPlanIdAndDeletedAtIsNull(Long goalPlanId);
+}

--- a/backend/src/main/java/com/example/focusapp/service/DailyTaskService.java
+++ b/backend/src/main/java/com/example/focusapp/service/DailyTaskService.java
@@ -7,10 +7,13 @@ import com.example.focusapp.dto.UpdateDailyTaskRequest;
 import com.example.focusapp.entity.DailyTask;
 import com.example.focusapp.entity.GoalConfig;
 import com.example.focusapp.entity.GoalPlan;
+import com.example.focusapp.entity.Routine;
 import com.example.focusapp.exception.NotFoundException;
+import com.example.focusapp.exception.BadRequestException;
 import com.example.focusapp.repository.DailyTaskRepository;
 import com.example.focusapp.repository.GoalPlanRepository;
 import com.example.focusapp.repository.GoalConfigRepository;
+import com.example.focusapp.repository.RoutineRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -31,6 +34,7 @@ public class DailyTaskService {
     private final DailyTaskRepository dailyTaskRepository;
     private final GoalPlanRepository goalPlanRepository;
     private final GoalConfigRepository goalConfigRepository;
+    private final RoutineRepository routineRepository;
     private final Random random = new Random();
 
     /**
@@ -80,12 +84,13 @@ public class DailyTaskService {
      */
     @Transactional
     public DailyTaskResponse toggle(Long id) {
+
         DailyTask dailyTask = dailyTaskRepository.findById(id)
                 .orElseThrow(() -> new NotFoundException("DailyTask 없음"));
 
         GoalPlan goalPlan = dailyTask.getGoalPlan();
 
-        int beforeLevel = goalPlan.getCurrentLevel(); // ⭐ 이전 레벨 저장
+        int beforeLevel = goalPlan.getCurrentLevel();
 
         dailyTask.setCompleted(!dailyTask.isCompleted());
 
@@ -108,6 +113,7 @@ public class DailyTaskService {
         return new DailyTaskResponse(
                 dailyTask.getId(),
                 goalPlan.getId(),
+                dailyTask.getRoutine() != null ? dailyTask.getRoutine().getId() : null,
                 dailyTask.getTitle(),
                 dailyTask.isCompleted(),
                 afterLevel,
@@ -231,6 +237,7 @@ public class DailyTaskService {
 
     @Transactional
     public DailyTaskResponse create(CreateDailyTaskRequest req) {
+
         GoalPlan goalPlan = goalPlanRepository.findById(req.getGoalPlanId())
                 .orElseThrow(() -> new NotFoundException("GoalPlan 없음"));
 
@@ -238,7 +245,13 @@ public class DailyTaskService {
         task.setGoalPlan(goalPlan);
         task.setTitle(req.getTitle());
         task.setCompleted(false);
-        task.setTargetDate(LocalDate.now());
+        task.setTargetDate(req.getTargetDate());
+
+        if (req.getRoutineId() != null) {
+            Routine routine = routineRepository.findById(req.getRoutineId())
+                    .orElseThrow(() -> new NotFoundException("Routine 없음"));
+            task.setRoutine(routine);
+        }
 
         dailyTaskRepository.save(task);
 
@@ -247,18 +260,24 @@ public class DailyTaskService {
         return new DailyTaskResponse(
                 task.getId(),
                 goalPlan.getId(),
+                task.getRoutine() != null ? task.getRoutine().getId() : null,
                 task.getTitle(),
                 task.isCompleted(),
                 goalPlan.getCurrentLevel()
         );
     }
+
     @Transactional
     public DailyTaskResponse updateTitle(Long id, String title) {
         DailyTask task = dailyTaskRepository.findById(id)
                 .orElseThrow(() -> new NotFoundException("Task 없음"));
 
         if (title == null || title.trim().isEmpty()) {
-            throw new IllegalArgumentException("제목은 비어 있을 수 없습니다");
+            throw new BadRequestException("제목은 비어 있을 수 없습니다");
+        }
+
+        if (task.getRoutine() != null) {
+            throw new BadRequestException("루틴 기반 task는 수정할 수 없습니다");
         }
 
         task.setTitle(title.trim());
@@ -266,6 +285,7 @@ public class DailyTaskService {
         return new DailyTaskResponse(
                 task.getId(),
                 task.getGoalPlan().getId(),
+                task.getRoutine() != null ? task.getRoutine().getId() : null,
                 task.getTitle(),
                 task.isCompleted(),
                 task.getGoalPlan().getCurrentLevel()
@@ -277,8 +297,15 @@ public class DailyTaskService {
         DailyTask task = dailyTaskRepository.findById(id)
                 .orElseThrow(() -> new NotFoundException("Task 없음"));
 
-        GoalPlan goalPlan = task.getGoalPlan();
+        if (task.getDeletedAt() != null) {
+            throw new NotFoundException("이미 삭제된 Task");
+        }
 
+        if (task.getRoutine() != null) {
+            throw new BadRequestException("루틴 task는 삭제할 수 없습니다");
+        }
+
+        GoalPlan goalPlan = task.getGoalPlan();
         dailyTaskRepository.delete(task);
         recalculateLevel(goalPlan);
     }

--- a/backend/src/main/java/com/example/focusapp/service/RoutineService.java
+++ b/backend/src/main/java/com/example/focusapp/service/RoutineService.java
@@ -1,0 +1,93 @@
+package com.example.focusapp.service;
+
+import com.example.focusapp.dto.DailyTaskResponse;
+import com.example.focusapp.dto.CreateRoutineRequest;
+import com.example.focusapp.dto.MessageType;
+import com.example.focusapp.dto.CreateDailyTaskRequest;
+import com.example.focusapp.dto.UpdateDailyTaskRequest;
+import com.example.focusapp.dto.RoutineResponse;
+import com.example.focusapp.entity.DailyTask;
+import com.example.focusapp.entity.GoalPlan;
+import com.example.focusapp.entity.Routine;
+import com.example.focusapp.exception.NotFoundException;
+import com.example.focusapp.repository.DailyTaskRepository;
+import com.example.focusapp.repository.RoutineRepository;
+import com.example.focusapp.repository.GoalPlanRepository;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import lombok.RequiredArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class RoutineService {
+
+    private final RoutineRepository routineRepository;
+    private final GoalPlanRepository goalPlanRepository;
+    private final DailyTaskRepository dailyTaskRepository;
+
+    @Transactional
+    public void createRoutine(CreateRoutineRequest req) {
+
+        GoalPlan goalPlan = goalPlanRepository.findById(req.getGoalPlanId())
+                .orElseThrow(() -> new NotFoundException("GoalPlan 없음"));
+
+        Routine routine = new Routine();
+        routine.setGoalPlan(goalPlan);
+        routine.setTitle(req.getTitle());
+        routine.setStartDate(req.getStartDate());
+        routine.setEndDate(req.getEndDate());
+        routine.setInterval(req.getInterval());
+        routine.setTime(req.getTime());
+
+        routineRepository.save(routine);
+
+        generateDailyTasksFromRoutine(routine);
+    }
+
+    private void generateDailyTasksFromRoutine(Routine routine) {
+
+        LocalDate date = routine.getStartDate();
+
+        while (!date.isAfter(routine.getEndDate())) {
+
+            boolean exists = dailyTaskRepository
+                    .existsByRoutineAndTargetDate(routine, date);
+
+            if (!exists) {
+                DailyTask task = new DailyTask();
+                task.setGoalPlan(routine.getGoalPlan());
+                task.setRoutine(routine); // 🔥 핵심 연결
+                task.setTitle(routine.getTitle());
+                task.setTargetDate(date);
+                task.setCompleted(false);
+
+                dailyTaskRepository.save(task);
+            }
+
+            date = date.plusDays(routine.getInterval());
+        }
+    }
+
+    public List<Routine> getRoutinesByGoal(Long goalPlanId) {
+
+        return routineRepository.findByGoalPlanId(goalPlanId);
+    }
+
+    @Transactional
+    public void deleteRoutine(Long id) {
+        Routine routine = routineRepository.findById(id)
+                .orElseThrow(() -> new NotFoundException("루틴 없음"));
+
+        routineRepository.delete(routine);
+
+        List<DailyTask> tasks = dailyTaskRepository.findByRoutineIdAndDeletedAtIsNull(id);
+        for (DailyTask task : tasks) {
+            task.setDeletedAt(LocalDateTime.now());
+        }
+    }
+}

--- a/frontend/src/components/DailyTaskSection.tsx
+++ b/frontend/src/components/DailyTaskSection.tsx
@@ -79,6 +79,7 @@ export default function DailyTaskSection({
                 const res = await api.post(`/daily-tasks`, {
                     goalPlanId,
                     title,
+                    targetDate: selectedDate,
                 });
 
                 setTasks((prev) => [...prev, res.data]);
@@ -100,6 +101,15 @@ export default function DailyTaskSection({
     const handleDelete = async () => {
         if (!isActive) return;
         if (!editTaskItem) return;
+        if (editTaskItem.routineId) {
+            Toast.show({
+                type: 'info',
+                text1: '루틴으로 생성된 할 일은 삭제할 수 없습니다',
+                position: 'bottom',
+            });
+            return;
+        }
+
         const id = editTaskItem.id;
         const prevTasks = tasks;
         setTasks((prev) => prev.filter((t) => t.id !== id));
@@ -125,6 +135,14 @@ export default function DailyTaskSection({
 
     const handleLongPress = (task: Task) => {
         if (!isActive) return;
+        if (task.routineId) {
+            Toast.show({
+                type: 'info',
+                text1: '루틴으로 생성된 할 일은 수정할 수 없습니다',
+                position: 'bottom',
+            });
+            return;
+        }
         setEditTaskItem(task);
         setModalVisible(true);
     };

--- a/frontend/src/screens/HomeScreen.tsx
+++ b/frontend/src/screens/HomeScreen.tsx
@@ -95,8 +95,6 @@ export default function HomeScreen({ navigation }: Props) {
             }
 
             if (savedUserId) {
-                const uid = Number(savedUserId);
-                await fetchCharacter(uid);
                 setUserId(savedUserId);
             }
         } catch (e) {
@@ -106,7 +104,7 @@ export default function HomeScreen({ navigation }: Props) {
 
     useFocusEffect(
         useCallback(() => {
-            loadInitial();
+            loadData();
         }, [])
     );
 
@@ -121,6 +119,7 @@ export default function HomeScreen({ navigation }: Props) {
 
     const fetchCharacter = async () => {
         try {
+            if (!goalPlanId) return;
             const res = await api.get(`/characters/current?goalPlanId=${goalPlanId}`);
             setCharacterImageUrl(res.data.imageUrl);
             setCurrentLevel(res.data.level);
@@ -149,7 +148,7 @@ export default function HomeScreen({ navigation }: Props) {
 
     const onRefresh = async () => {
         setRefreshing(true);
-        await loadInitial();
+        await loadData();
         setRefreshKey(prev => prev + 1);
         setRefreshing(false);
     };

--- a/frontend/src/screens/RoutineCreateScreen.tsx
+++ b/frontend/src/screens/RoutineCreateScreen.tsx
@@ -52,15 +52,28 @@ export default function RoutineCreateScreen({ route, navigation }: Props) {
 
         try {
             setLoading(true);
-            //수정필요 (실제 api주소로)
+
+            const today = new Date();
+
+            const finalStartDate = startDate ?? today;
+
+            const finalEndDate = endDate ?? new Date(
+                finalStartDate.getFullYear() + 1,
+                finalStartDate.getMonth(),
+                finalStartDate.getDate()
+            );
+
+            const interval = parseInterval(repeatCycle);
+
+            const formattedTime = getFormattedTime();
+
             await api.post('/routines', {
-                goalId: Number(goalId),
+                goalPlanId: Number(goalId),
                 title: title.trim(),
-                startDate: startDate ? formatDate(startDate) : formatDate(new Date()),
-                endDate: endDate ? formatDate(endDate) : formatDate(new Date()),
-                repeatCycle,
-                time: time === '없음' ? null : time,
-                manualAdd,
+                startDate: formatDate(finalStartDate),
+                endDate: formatDate(finalEndDate),
+                interval: interval,
+                time: formattedTime,
             });
 
             Alert.alert('완료', '루틴이 생성되었습니다.');
@@ -71,6 +84,29 @@ export default function RoutineCreateScreen({ route, navigation }: Props) {
         } finally {
             setLoading(false);
         }
+    };
+
+    const getFormattedTime = (): string | null => {
+        if (time === '없음') return null;
+
+        let h = hour;
+
+        if (ampm === 'PM' && hour < 12) h += 12;
+        if (ampm === 'AM' && hour === 12) h = 0;
+
+        return `${String(h).padStart(2, '0')}:${String(minute).padStart(2, '0')}:00`;
+    };
+
+    const parseInterval = (cycle: string): number | null => {
+        if (cycle === '매일') return 1;
+        if (cycle === '일주일마다') return 7;
+        if (cycle === '매월') return 30;
+        if (cycle === '매년') return 365;
+
+        const match = cycle.match(/(\d+)일마다/);
+        if (match) return Number(match[1]);
+
+        return 1;
     };
 
     return (

--- a/frontend/src/screens/RoutineManageScreen.tsx
+++ b/frontend/src/screens/RoutineManageScreen.tsx
@@ -53,6 +53,8 @@ function stringToColor(str: string) {
 export default function RoutineManageScreen({ route, navigation }: Props) {
     const [categories, setCategories] = useState<Category[]>([]);
     const [loading, setLoading] = useState(true);
+    const [expandedId, setExpandedId] = useState<string | null>(null);
+    const [routinesMap, setRoutinesMap] = useState<Record<string, any[]>>({});
 
     useEffect(() => {
         const fetchData = async () => {
@@ -64,7 +66,7 @@ export default function RoutineManageScreen({ route, navigation }: Props) {
                     return;
                 }
 
-                const res = await api.get<GoalResponse[]>(`/goals/users/${userId}`);
+                const res = await api.get<GoalResponse[]>(`/goals/users/${userId}/active`);
 
                 const data = res.data;
 
@@ -84,9 +86,48 @@ export default function RoutineManageScreen({ route, navigation }: Props) {
         fetchData();
     }, [route.params]);
 
-
     const handlePressCategory = (category: Category) => {
         navigation.navigate('RoutineCreate', { goalId: category.id });
+    };
+
+    const fetchRoutines = async (goalId: string) => {
+        try {
+            const res = await api.get(`/routines`, {
+                params: { goalPlanId: goalId }
+            });
+
+            setRoutinesMap((prev) => ({
+                ...prev,
+                [goalId]: res.data,
+            }));
+        } catch (e) {
+            console.error('루틴 조회 실패', e);
+        }
+    };
+
+    const toggleExpand = async (goalId: string) => {
+        if (expandedId === goalId) {
+            setExpandedId(null);
+        } else {
+            setExpandedId(goalId);
+
+            if (!routinesMap[goalId]) {
+                await fetchRoutines(goalId);
+            }
+        }
+    };
+
+    const deleteRoutine = async (routineId: number, goalId: string) => {
+        try {
+            await api.delete(`/routines/${routineId}`);
+
+            setRoutinesMap((prev) => ({
+                ...prev,
+                [goalId]: prev[goalId].filter((r) => r.id !== routineId),
+            }));
+        } catch (e) {
+            console.error('루틴 삭제 실패', e);
+        }
     };
 
     if (loading) {
@@ -113,25 +154,55 @@ export default function RoutineManageScreen({ route, navigation }: Props) {
                 카테고리를 선택하여 해당 카테고리의 루틴을 추가할 수 있습니다.
             </Text>
 
-            <View style={styles.categoryList}>
-                {categories.map((category) => {
-                    const color = stringToColor(category.name);
+            {categories.map((category) => {
+                const isExpanded = expandedId === category.id;
+                const color = stringToColor(category.name);
 
-                    return (
+                return (
+                    <View key={category.id} style={styles.card}>
+                        {/* 🔽 헤더 */}
                         <TouchableOpacity
-                            key={category.id}
-                            style={styles.categoryButton}
-                            onPress={() => handlePressCategory(category)}
+                            style={[styles.categoryButton, { color }]}
+                            onPress={() => toggleExpand(category.id)}
                         >
                             <Text style={[styles.categoryText, { color }]}>
                                 {category.name}
                             </Text>
 
-                            <Ionicons name="add-circle-outline" size={30} color="#fff" />
+                            <View style={{ flexDirection: 'row', alignItems: 'center', gap: 10 }}>
+                                <Ionicons name="add-circle-outline" size={26} color="#fff"
+                                          onPress={() =>
+                                              navigation.navigate('RoutineCreate', { goalId: category.id })
+                                          }
+                                />
+
+                                <Text style={styles.arrow}>
+                                    {isExpanded ? '▲' : '▼'}
+                                </Text>
+                            </View>
                         </TouchableOpacity>
-                    );
-                })}
-            </View>
+
+                        {/* 🔽 펼쳐진 루틴 리스트 */}
+                        {isExpanded && (
+                            <View style={styles.routineBox}>
+                                {(routinesMap[category.id] || []).map((routine) => (
+                                    <View key={routine.id} style={styles.routineRow}>
+                                        <Text style={styles.routineText}>
+                                            {routine.title}
+                                        </Text>
+
+                                        <TouchableOpacity
+                                            onPress={() => deleteRoutine(routine.id, category.id)}
+                                        >
+                                            <Text style={styles.deleteBtn}>삭제</Text>
+                                        </TouchableOpacity>
+                                    </View>
+                                ))}
+                            </View>
+                        )}
+                    </View>
+                );
+            })}
         </ScrollView>
     );
 }
@@ -214,5 +285,41 @@ const styles = StyleSheet.create({
         fontSize: 24,
         fontWeight: '500',
         marginTop: -2,
+    },
+    card: {
+        borderRadius: 18,
+        backgroundColor: '#17171B',
+        borderWidth: 1,
+        borderColor: '#25252B',
+        overflow: 'hidden',
+    },
+
+    arrow: {
+        color: '#8B8B94',
+        fontSize: 12,
+    },
+
+    routineBox: {
+        borderTopWidth: 1,
+        borderTopColor: '#25252B',
+        padding: 12,
+        gap: 8,
+    },
+
+    routineRow: {
+        flexDirection: 'row',
+        justifyContent: 'space-between',
+        alignItems: 'center',
+    },
+
+    routineText: {
+        color: '#fff',
+        fontSize: 14,
+    },
+
+    deleteBtn: {
+        color: '#FF5F5F',
+        fontSize: 13,
+        fontWeight: '700',
     },
 });

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -8,6 +8,7 @@ export type GoalCategory = {
 };
 
 export type Task = {
+  routineId: boolean;
   id: number;
   title: string;
   completed: boolean;


### PR DESCRIPTION
### 🚀 작업 요약

* 루틴 조회/생성/삭제 기능 구현 및 DailyTask soft delete 적용, 루틴 카드 UI 연동

---

### 🛠️ 주요 변경 사항

#### 1. Backend (Spring Boot)

* [x] **Entity/Repository**

  * Routine, DailyTask 엔티티에 `deleted_at` 컬럼 추가 (soft delete)
  * RoutineRepository, DailyTaskRepository 조회 조건 보완

* [x] **Service/Controller**

  * 루틴 생성 로직 구현
  * 루틴 조회 로직 구현 (goalPlanId 기준)
  * 루틴 삭제 시 DailyTask 함께 soft delete 처리

* [x] **API Endpoint**

  * `GET /api/routines?goalPlanId={id}` 루틴 조회 추가
  * `POST /api/routines` 루틴 생성
  * `DELETE /api/routines/{id}` 루틴 삭제

---

#### 2. Frontend (React Native)

* [x] **Logic**

  * goal → routine 목록 조회 연동
  * 루틴 펼침(toggle) 시 API 호출 및 상태 관리
  * 루틴 삭제 후 리스트 갱신 처리

* [x] **UI/UX**

  * 기존 카테고리 버튼 → 카드 형태 UI 변경
  * 루틴 리스트 expand/collapse UI 구현
  * 루틴 추가 버튼 및 삭제 버튼 UI 적용

---

#### 3. Database (MySQL / RDS)

* [x] **Schema 변경**

  * `daily_tasks.deleted_at` 컬럼 추가

* [x] **Data**

  * soft delete 기반 조회로 기존 데이터 영향 없이 동작

---

### 🧪 테스트 및 검증 결과

* [x] **API Test**

  * 루틴 조회/생성/삭제 정상 동작 확인
  * soft delete 적용 후 조회 시 제외 확인

* [x] **UI Test**

  * 루틴 카드 expand/collapse 정상 동작
  * 루틴 추가/삭제 시 즉시 UI 반영 확인

---

### ⚠️ 리뷰어 전달 사항

* **확인 요청**: UI 변경으로 일부 어색한 부분이 있을 수 있어, 확인 후 추가 수정 의견 부탁드립니다.